### PR TITLE
Add Secret Management and Blade SSH Keys

### DIFF
--- a/vtds_provider_gcp/api_objects.py
+++ b/vtds_provider_gcp/api_objects.py
@@ -148,3 +148,30 @@ class BladeConnection(metaclass=ABCMeta):
         address of the connection to the Virtual Blade.
 
         """
+
+
+class Secrets:
+    """Provider Layers Secrets API object. Provides ways to populate
+    and retrieve secrets through the Provider layer. Secrets are
+    created by the provider layer by declaring them in the Provider
+    configuration for your vTDS system, and should be known by their
+    names as filled out in various places and verious layers in your
+    vTDS system. For example the SSH key pair used to talk to a
+    particular set of Virtual Blades through a blade connection is
+    stored in a secret configured in the Provider layer and the name
+    of that secret can be obtained from a VirtualBlades API object
+    using the blade_ssh_key_secret() method.
+
+    """
+    @abstractmethod
+    def store(self, name, value):
+        """Store a value (string) in the named secret.
+
+        """
+
+    @abstractmethod
+    def read(self, name):
+        """Read the value (string) stored in a named secret. If no
+        value is present, return None.
+
+        """

--- a/vtds_provider_gcp/private/blade_interconnect.py
+++ b/vtds_provider_gcp/private/blade_interconnect.py
@@ -75,9 +75,9 @@ class BladeInterconnect:
         }
 
     @classmethod
-    def _convert_firewalls(cls, interconnect_config):
-        """Convert ingress and egress firewall rules in a
-        blade-interconnect configuration from maps to lists so that
+    def __convert_firewalls(cls, interconnect_config):
+        """Class Private: Convert ingress and egress firewall rules in
+        a blade-interconnect configuration from maps to lists so that
         terragrunt can use them.
 
         """
@@ -116,7 +116,7 @@ class BladeInterconnect:
 
         """
         # Convert the firewall rule maps into lists for terragrunt
-        interconnect_config = self._convert_firewalls(interconnect_config)
+        interconnect_config = self.__convert_firewalls(interconnect_config)
 
         # Locate the top of the template for blade_interconnects
         template_dir = self.terragrunt.template_path(

--- a/vtds_provider_gcp/private/common.py
+++ b/vtds_provider_gcp/private/common.py
@@ -1,0 +1,301 @@
+#
+# MIT License
+#
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""A class that provides common tools based on configuration
+and so forth that relate to the GCP vTDS provider.
+
+"""
+from os.path import join as path_join
+from subprocess import (
+    PIPE
+)
+
+from vtds_base import (
+    ContextualError,
+    run,
+    log_paths
+)
+
+
+class Common:
+    """A class that provides common tools based on configuration and
+    so forth that relate to the GCP vTDS provider.
+
+    """
+    # For caching purposes, once a project ID has been computed it
+    # will be shared among all instances. Worst case (in case of
+    # multi-threading) we compute this twice before one of the threads
+    # assigns a value to it. The value will be the same no matter who
+    # assigns it, and assignment itself should be atomic, so no real
+    # threading issues to worry about.
+    project_id = None
+
+    def __init__(self, config, build_dir):
+        """Constructor.
+
+        """
+        self.config = config
+        self.build_directory = build_dir
+
+    def __get_blade(self, blade_type):
+        """class private: retrieve the blade type deascription for the
+        named type.
+
+        """
+        virtual_blades = (
+            self.config.get('virtual_blades', {})
+        )
+        blade = virtual_blades.get(blade_type, None)
+        if blade is None:
+            raise ContextualError(
+                "cannot find the virtual blade type '%s'" % blade_type
+            )
+        if blade.get('pure_base_class', False):
+            raise ContextualError(
+                "blade type '%s' is a pure pure base class" % blade_type
+            )
+        return blade
+
+    def __get_blade_interconnect(self, blade_type, interconnect):
+        """class private: Get the named interconnect information from
+        the specified Virtual Blade type.
+
+        """
+        blade = self.__get_blade(blade_type)
+        blade_interconnect = blade.get('blade_interconnect', None)
+        if blade_interconnect is None:
+            raise ContextualError(
+                "provider config error: Virtual Blade type '%s' has no "
+                "blade interconnect configured" % blade_type
+            )
+        if blade_interconnect.get("subnetwork", None) != interconnect:
+            raise ContextualError(
+                "Virtual Blade type '%s' is not configured to use "
+                "blade interconnect '%s'" % (blade_type, interconnect)
+            )
+        return blade_interconnect
+
+    def __check_blade_instance(self, blade_type, instance):
+        """class private: Ensure that the specified instance number
+        for a given blade type (blades) is legal.
+
+        """
+        if not isinstance(instance, int):
+            raise ContextualError(
+                "Virtual Blade instance number must be integer not '%s'" %
+                type(instance)
+            )
+        blade = self.__get_blade(blade_type)
+        count = int(blade.get('count', 0))
+        if instance < 0 or instance >= count:
+            raise ContextualError(
+                "instance number %d out of range for Virtual Blade "
+                "type '%s' which has a count of %d" %
+                (instance, blade_type, count)
+            )
+
+    def get_config(self):
+        """Get the full config data stored here.
+
+        """
+        return self.config
+
+    def get(self, key, default):
+        """Perform a 'get' operation on the top level 'config' object
+        returning the value of 'default' if 'key' is not found.
+
+        """
+        return self.config.get(key, default)
+
+    def build_dir(self):
+        """Return the 'build_dir' provided at creation.
+
+        """
+        return self.build_directory
+
+    def get_project_id(self):
+        """layer private: Retrieve the project ID for the current vTDS
+        project.
+
+        """
+        if self.project_id is not None:
+            return self.project_id
+        organization_name = (
+            self.config.get('organization', {}).get('name', None)
+        )
+        if organization_name is None:
+            raise ContextualError(
+                "provider config error: cannot find 'name' in "
+                "'provider.organization'"
+            )
+        base_name = (
+            self.config.get('project', {}).get('base_name', None)
+        )
+        if base_name is None:
+            raise ContextualError(
+                "provider config error: cannot find 'base_name' in "
+                "'provider.project'"
+            )
+        project_name = "%s-%s" % (organization_name, base_name)
+        result = run(
+            [
+                'gcloud', 'projects', 'list',
+                '--filter=name=%s' % project_name,
+                '--format=value(PROJECT_ID)'
+            ],
+            log_paths(self.build_directory, "common-get-project-id"),
+            stdout=PIPE
+        )
+        # Reference the class variable using the class name to set it.
+        Common.project_id = result.stdout.rstrip()
+        return self.project_id
+
+    def get_zone(self):
+        """Layer private: get the configured zone in which resources
+        for this project reside.
+
+        """
+        zone = self.config.get('project', {}).get('zone', None)
+        if zone is None:
+            raise ContextualError(
+                "provider config error: cannot find 'zone' in "
+                "'provider.project'"
+            )
+        return zone
+
+    def blade_hostname(self, blade_type, instance):
+        """Get the hostname of a given instance of the specified type
+        of Virtual Blade.
+
+        """
+        self.__check_blade_instance(blade_type, instance)
+        blade = self.__get_blade(blade_type)
+        if 'hostname' not in blade:
+            raise ContextualError(
+                "provider config error: no 'hostname' configured for "
+                "Virtual Blade type '%s'" % blade_type
+            )
+        count = self.blade_count(blade_type)
+        add_suffix = blade.get('add_hostname_suffix', count > 1)
+        hostname = blade['hostname']
+        separator = (
+            blade.get('hostname_suffix_separator', "") if add_suffix else ""
+        )
+        # Suffixes are 1 based, not 0 based, instances are 0 based
+        suffix = "%3.3d" % (instance + 1) if add_suffix else ""
+        return hostname + separator + suffix
+
+    def blade_ip(self, blade_type, instance, interconnect):
+        """Return the IP address (string) on the named Blade
+        Interconnect of a specified instance of the named Virtual
+        Blade type.
+
+        """
+        self.__check_blade_instance(blade_type, instance)
+        blade_interconnect = self.__get_blade_interconnect(
+            blade_type, interconnect
+        )
+        ip_addrs = blade_interconnect.get('ip_addrs', None)
+        if not ip_addrs:
+            raise ContextualError(
+                "provider config error: Virtual Blade type '%s' has no "
+                "'ip_addrs' configured"
+            )
+        if instance >= len(ip_addrs):
+            raise ContextualError(
+                "provider config error: Virtual Blade type is configured with "
+                "fewer ip_addrs (%d) than blade instances (%d)" %
+                (len(ip_addrs), self.blade_count(blade_type))
+            )
+        return ip_addrs[instance]
+
+    def blade_count(self, blade_type):
+        """Get the number of Virtual Blade instances of the specified
+        type.
+
+        """
+        blade = self.__get_blade(blade_type)
+        return int(blade.get('count', 0))
+
+    def blade_interconnects(self, blade_type):
+        """Return the list of Blade Interconnects by name connected to
+        the specified type of Virtual Blade.
+
+        """
+        blade = self.__get_blade(blade_type)
+        # The GCP provider only lets us have one interconnect per
+        # blade type, so we are just going to go grab that and make it
+        # into a 'list' of one item.
+        name = blade.get('blade_interconnect', {}).get('subnetwork', None)
+        if name is None:
+            raise ContextualError(
+                "provider config error: no 'blade_interconnect.subnetwork' "
+                "found in blade type '%s'" % blade_type
+            )
+        return [name]
+
+    def blade_ssh_key_secret(self, blade_type):
+        """Return the name of the secret used to store the SSH key
+        pair used to reach blades of the specified type through a
+        tunneled SSH connection.
+
+        """
+        blade = self.__get_blade(blade_type)
+        # The GCP provider only lets us have one interconnect per
+        # blade type, so we are just going to go grab that and make it
+        # into a 'list' of one item.
+        secret_name = blade.get('ssh_key_secret', None)
+        if secret_name is None:
+            raise ContextualError(
+                "provider config error: no 'ssh_key_secret' "
+                "found in blade type '%s'" % blade_type
+            )
+        return secret_name
+
+    def ssh_key_paths(self, secret_name, ignore_missing=False):
+        """Return a tuple of paths to files containing the public and
+        private SSH keys used to to authenticate with blades of the
+        specified blade type. The tuple is in the form '(public_path,
+        private_path)' The value of 'private_path' is suitable for use
+        with the '-i' option of 'ssh'. If 'ignore_missing' is set, to
+        True, the path names will be generated, but no check will be
+        done to verify that the files exist. By default, or if
+        'ignore_missing' is set to False, this function will verify
+        that the files can be opened for reading and raise a
+        ContextualError if they cannot.
+
+        """
+        ssh_dir = path_join(self.build_dir(), 'blade_ssh_keys', secret_name)
+        private_path = path_join(ssh_dir, "id_rsa")
+        public_path = path_join(ssh_dir, "id_rsa.pub")
+        if not ignore_missing:
+            try:
+                # pylint: disable=consider-using-with
+                open(public_path, 'r', encoding='UTF-8').close()
+                # pylint: disable=consider-using-with
+                open(private_path, 'r', encoding='UTF-8').close()
+            except OSError as err:
+                raise ContextualError(
+                    "failed to open SSH key file for reading "
+                    "(verification) - %s" % str(err)
+                ) from err
+        return (public_path, private_path)

--- a/vtds_provider_gcp/private/config/config.yaml
+++ b/vtds_provider_gcp/private/config/config.yaml
@@ -84,6 +84,7 @@ provider:
       - "cloudresourcemanager.googleapis.com"
       - "iam.googleapis.com"
       - "serviceusage.googleapis.com"
+      - "secretmanager.googleapis.com"
 
     auto_create_network: false
 
@@ -326,6 +327,13 @@ provider:
             disk_type: "pd-standard"
             disk_labels: {}
             source_snapshot: null
+      # This is the name of the secret that will be set up to hold
+      # the SSH key needed to connect by SSH to blades of this
+      # class. If you want to isolate blades of different classes to
+      # different SSH users, you can do that by creating different
+      # secrets and using them here instead of this one for those
+      # derived classes.
+      ssh_key_secret: blade-ssh-key
       blade_interconnect:
         network: ""
         subnetwork: "base-interconnect"
@@ -377,3 +385,20 @@ provider:
       ipv6_access_config: []
       gpu: null
       resource_policies: []
+  secrets:
+    blade_ssh_keys:
+      # The SSH public / private key pair used by the provider layer
+      # to talk to Virtual Blades. The public key will be added to
+      # '/root/.ssh/authorized_keys' upon deployment of virtual
+      # blades.
+      name: blade-ssh-key
+      # Key value pairs used as labels in the secret to identify
+      # its function. Generally not used, but here if you want it. No
+      # more than 64 labels can be assigned.
+      labels: {}
+      # Key value pairs, similar to labels. There will always be
+      # a 'layer' annotation indicating what layer requested creation
+      # of the secret. The total size of annotation keys and values
+      # must be less than 16KiB.
+      annotations:
+        layer: provider

--- a/vtds_provider_gcp/private/private_provider.py
+++ b/vtds_provider_gcp/private/private_provider.py
@@ -23,10 +23,20 @@
 """Private layer implementation module for the GCP provider.
 
 """
+from os.path import dirname
+from os import makedirs
+from shutil import rmtree
+from yaml import (
+    YAMLError,
+    safe_load,
+    safe_dump
+)
 
 from vtds_base import (
     ContextualError,
-    expand_inheritance
+    expand_inheritance,
+    run,
+    log_paths
 )
 
 # Import private classes
@@ -38,8 +48,11 @@ from .virtual_blade import VirtualBlade
 from .blade_interconnect import BladeInterconnect
 from .api_objects import (
     PrivateVirtualBlades,
-    PrivateBladeInterconnects
+    PrivateBladeInterconnects,
+    PrivateSecrets
 )
+from .common import Common
+from .secret_manager import SecretManager
 
 
 class PrivateProvider:
@@ -53,12 +66,118 @@ class PrivateProvider:
         caller that will drive all activities at all layers.
 
         """
-        self.config = config
-        self.build_dir = build_dir
-        self.terragrunt = Terragrunt(build_dir)
-        self.terragrunt_config = TerragruntConfig(self.terragrunt)
+        self.common = Common(config, build_dir)
+        self.terragrunt = Terragrunt(self.common)
+        self.terragrunt_config = TerragruntConfig(self.common, self.terragrunt)
+        self.secret_manager = SecretManager(self.common)
         self.stack = stack
         self.prepared = False
+
+    def __populate_blade_ssh_secret(self, secret_name):
+        """Set up an SSH key pair and store it in the named secret.
+
+        """
+        pub_key, priv_key = self.common.ssh_key_paths(secret_name, True)
+        ssh_dir = dirname(priv_key)
+
+        # Make sure there is a fresh empty directory in place for the keys.
+        rmtree(ssh_dir, ignore_errors=True)
+        makedirs(ssh_dir, mode=0o700, exist_ok=True)
+
+        # Make the keys.
+        run(
+            ['ssh-keygen', '-q', '-N', '', '-t', 'rsa', '-f', priv_key],
+            log_paths(self.common.build_dir(), "make-ssh-key-%s" % secret_name)
+        )
+
+        # Stash the keys in the secret
+        with open(priv_key, 'r', encoding='UTF-8') as private, \
+             open(pub_key, 'r', encoding='UTF-8') as public:
+            keys = {
+                'private': private.read(),
+                'public': public.read(),
+            }
+        secret = safe_dump(keys)
+        self.secret_manager.store(secret_name, secret)
+
+    def __authorize_blade_ssh_secret(self, secret_name):
+        """For all blades using the specified secret as their SSH key,
+        add the public key to the 'root' '.ssh/authorized_keys'
+        contents.
+
+        """
+        data = self.secret_manager.read(secret_name)
+        if data is None:
+            raise ContextualError(
+                "SSH key for secret '%s' is not yet populated" % secret_name
+            )
+        try:
+            public_key = safe_load(data)['public']
+        except KeyError as err:
+            raise ContextualError(
+                "data in SSH keys secret '%s' does not contain public key "
+                "field (data not shown to protect secret)" % secret_name
+            ) from err
+        except YAMLError as err:
+            raise ContextualError(
+                "data in SSH keys secret '%s' is not parsable YAML "
+                "(data and error not shown to protect secret)" % secret_name
+            ) from err
+        virtual_blades = self.get_virtual_blades()
+        blades = [
+            (blade_type, instance)
+            for blade_type in virtual_blades.blade_types()
+            if virtual_blades.blade_ssh_key_secret(blade_type) == secret_name
+            for instance in range(0, virtual_blades.blade_count(blade_type))
+        ]
+        project_id = self.common.get_project_id()
+        zone = self.common.get_zone()
+        for blade_type, instance in blades:
+            # Make sure SSH (port 22) is running on the remote
+            # blade. This operation happens early in startup, so it is
+            # necessary to let the blade boot and become ready. A side
+            # effect of connect_blade() is that it waits until it can
+            # establish a connection through the IAP connection before
+            # returning, so this is a good way to achive that ready
+            # wait.
+            virtual_blades.connect_blade(22, blade_type, instance)
+            # Append the public key to 'authorized_keys'
+            hostname = virtual_blades.blade_hostname(blade_type, instance)
+            run(
+                [
+                    'gcloud', 'compute', 'ssh', '--tunnel-through-iap',
+                    '--project=%s' % project_id, '--zone=%s' % zone,
+                    'root@%s' % hostname, '--',
+                    'cat >> /root/.ssh/authorized_keys'
+                ],
+                log_paths(
+                    self.common.build_dir(),
+                    "authorize-%s-on-%s" % (secret_name, hostname)
+                ),
+                input=public_key
+            )
+
+    def __setup_blade_ssh_secrets(self):
+        """For each unique secret used by a Virtual Blade type
+        generate an SSH key pair (in the build tree for temporary
+        storage) and store that key pair in the named secret. On
+        return, there is an SSH key pair stored in each secret, and,
+        for each secret, every blade using that secret has been set up
+        to authorize the public key from that secret.
+
+        """
+        virtual_blades = self.get_virtual_blades()
+        # Get all of the SSH key secret names for all blade types
+        secret_names = [
+            virtual_blades.blade_ssh_key_secret(blade_type)
+            for blade_type in virtual_blades.blade_types()
+        ]
+        # Coerce the list to a set then back to a list to ensure each
+        # name is unique in the final list.
+        secret_names = list(set(secret_names))
+        for secret_name in secret_names:
+            self.__populate_blade_ssh_secret(secret_name)
+            self.__authorize_blade_ssh_secret(secret_name)
 
     def prepare(self):
         """Prepare operation. This drives creation of the provider
@@ -67,8 +186,8 @@ class PrivateProvider:
         the foundation of a platform for the vTDS.
 
         """
-        self.terragrunt.initialize(self.config)
-        blade_types = self.config.get('virtual_blades', None)
+        self.terragrunt.initialize()
+        blade_types = self.common.get('virtual_blades', None)
         if blade_types is None:
             raise ContextualError(
                 "no virtual blade types found in vTDS provider configuration"
@@ -87,7 +206,7 @@ class PrivateProvider:
             virtual_blade = VirtualBlade(self.terragrunt)
             blade_config = virtual_blade.initialize(key, blade_config)
             blade_types[key] = blade_config
-        interconnect_types = self.config.get('blade_interconnects', None)
+        interconnect_types = self.common.get('blade_interconnects', None)
         if interconnect_types is None:
             raise ContextualError(
                 "no blade interconnect types found in vTDS provider "
@@ -108,7 +227,7 @@ class PrivateProvider:
         # Now that we have fully expanded all of the inheritance and
         # set up the terragrunt controls for everything that is going
         # to get them, set up the terragrunt configuration.
-        self.terragrunt_config.initialize(self.config)
+        self.terragrunt_config.initialize()
 
         # All done with the preparations: make a note that we have
         # done them and return.
@@ -138,6 +257,8 @@ class PrivateProvider:
                 "cannot deploy an unprepared provider, call prepare() first"
             )
         self.terragrunt.deploy()
+        self.secret_manager.deploy()
+        self.__setup_blade_ssh_secrets()
 
     def shutdown(self, virtual_blade_names):
         """Shutdown operation. This will shut down (power off) the
@@ -196,11 +317,18 @@ class PrivateProvider:
         available non-pure-base-class Virtual Blades.
 
         """
-        return PrivateVirtualBlades(self.config, self.build_dir)
+        return PrivateVirtualBlades(self.common)
 
     def get_blade_interconnects(self):
         """Return a BladeInterconnects object containing all the
         available non-pure-base-class Blade Interconnects.
 
         """
-        return PrivateBladeInterconnects(self.config, self.build_dir)
+        return PrivateBladeInterconnects(self.common)
+
+    def get_secrets(self):
+        """Return a Secrets API object that provides access to all
+        available secrets.
+
+        """
+        return PrivateSecrets(self.secret_manager)

--- a/vtds_provider_gcp/private/secret_manager.py
+++ b/vtds_provider_gcp/private/secret_manager.py
@@ -1,0 +1,224 @@
+#
+# MIT License
+#
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""Private layer code to compose and work with dynamically created
+Terragrunt / Terraform control structures that define the resources
+associated with classes of vTDS Virtual Blades for the purpose of
+deploying Virtual Blades implemented as GCP Compute Instances into a
+platform implemented as a GCP project.
+
+"""
+import re
+from subprocess import PIPE
+from vtds_base import (
+    ContextualError,
+    log_paths,
+    run
+)
+
+
+class SecretManager:
+    """Class providing operations for creating and removing secrets as
+    needed from a the GCP secret manager.
+
+    """
+    def __init__(self, common):
+        """Constructor
+
+        """
+        self.common = common
+        secrets = self.common.get('secrets', {})
+        try:
+            self.secrets = {
+                secret['name']: secret for _, secret in secrets.items()
+            }
+        except KeyError as err:
+            # No harm compiling a list since we are going to error out
+            # anyway. This will provide a more useful error.
+            missing_names = [
+                key for key, secret in secrets.items() if 'name' not in secret
+            ]
+            raise ContextualError(
+                "configuration error: the following secrets (by key) in the "
+                "config do not define a 'name' field: %s" % str(missing_names)
+            ) from err
+        self.cache = {}
+
+    @staticmethod
+    def __expand_kvs(secret_name, dict_name, dictionary):
+        """Class private: expand a dictionary of key-value pairs into
+        a string of the form: '<key>=<value>[,<key>=<value>][,...]'
+        for use in 'gcloud' commands. Neither a key nor a value may
+        contain whitespace.
+
+        """
+        valid = re.compile(r"^[^\s]*$")
+        result = ""
+        for key, value in dictionary.items():
+            if not valid.match(key) or not valid.match(value):
+                raise ContextualError(
+                    "secret '%s' has whitespace in '%s' entry ['%s':'%s']" % (
+                        secret_name, dict_name, key, value
+                    )
+                )
+            result += "," if result else ""
+            result += "%s=%s" % (key, value)
+        return result
+
+    def __create_secret(self, secret):
+        """Class private: register the specified secret in the GCP
+        Secret Manager.
+
+        """
+        # I didn't get here if any of the secrets don't have names, so
+        # no need to protect this reference.
+        name = secret['name']
+        project_id = "--project=%s" % self.common.get_project_id()
+        cmd = ['gcloud', 'secrets', 'create', name, project_id]
+        # Set up the option to add labels if there are any needed
+        labels = (
+            "--labels=%s" % self.__expand_kvs(name, "labels", secret['labels'])
+            if secret.get('labels', None) else
+            ""
+        )
+        if labels:
+            cmd.append(labels)
+        # Set up the option to add annotations if there are any needed
+        annotations = (
+            "--set-annotations=%s" % self.__expand_kvs(
+                name, "annotations", secret['annotations']
+            )
+            if secret.get('annotations', None) else
+            ""
+        )
+        if annotations:
+            cmd.append(annotations)
+        logname = "create-secret-%s" % name
+        run(cmd, log_paths(self.common.build_dir(), logname))
+
+    def __remove_secret(self, secret):
+        """Class private: register the specified secret in the GCP
+        Secret Manager.
+
+        """
+        # I didn't get here if any of the secrets don't have names, so
+        # no need to protect this reference.
+        name = secret['name']
+        project_id = "--project=%s" % self.common.get_project_id()
+        logname = "remove-secret-%s" % name
+        run(
+            ['gcloud', 'secrets', 'delete', name, project_id, '--quiet'],
+            log_paths(self.common.build_dir(), logname)
+        )
+
+    def __store_secret(self, secret, data):
+        """Store the specified data in a secret (actually a secret
+        version in GCP).
+
+        """
+        # I didn't get here if any of the secrets don't have names, so
+        # no need to protect this reference.
+        name = secret['name']
+        project_id = "--project=%s" % self.common.get_project_id()
+        logname = "store-secret-%s" % name
+        run(
+            [
+                'gcloud', 'secrets', 'versions', 'add', project_id,
+                '--data-file=-', name,
+            ],
+            log_paths(self.common.build_dir(), logname),
+            input=data
+        )
+        # Keep a write-through cache of secrets that have been stored
+        # to expedite retrieving them in the future.
+        self.cache[name] = data
+
+    def __read_secret(self, secret):
+        """Read the 'latest' version data from the specified secret
+        and return it as a 'UTF-8' encoded string.
+
+        """
+        # I didn't get here if any of the secrets don't have names, so
+        # no need to protect this reference.
+        name = "--secret=%s" % secret['name']
+        # Try reading the secret from the cache, if it doesn't work go
+        # ahead and get it from GCP instead.
+        try:
+            return self.cache[name]
+        except KeyError:
+            # Not in the cache, keep looking...
+            pass
+        project_id = "--project=%s" % self.common.get_project_id()
+        logname = "read-secret-%s" % secret['name']
+        result = run(
+            [
+                'gcloud', 'secrets', 'versions', 'access', 'latest',
+                project_id, name,
+            ],
+            log_paths(self.common.build_dir(), logname),
+            stdout=PIPE
+        )
+        self.cache[name] = result.stdout.rstrip()
+        return self.cache[name]
+
+    def deploy(self):
+        """Deploy all secrets declared by any layer during the
+        'prepare' phase to the GCP Secret Manager. This creates the
+        secrets as place holders for content. It is up to the users of
+        the secrets to fill them with data (create versions in GCP
+        parlance) by calling into the provider API for storing data in
+        secrets.
+
+        """
+        for _, secret in self.secrets.items():
+            self.__create_secret(secret)
+
+    def remove(self):
+        """Remove all secrets declared by any layer during the
+        'prepare' phase from the GCP Secret Manager.
+
+        """
+        for _, secret in self.secrets.items():
+            self.__remove_secret(secret)
+
+    def store(self, name, value):
+        """Store a value in the named secret. The value should be a
+        UTF-8 encoded string.
+
+        """
+        secret = self.secrets.get(name, None)
+        if secret is None:
+            raise ContextualError(
+                "attempt to store value in unknown secret '%s'" % name
+            )
+        self.__store_secret(secret, value)
+
+    def read(self, name):
+        """Read the value of the named secret.
+
+        """
+        secret = self.secrets.get(name, None)
+        if secret is None:
+            raise ContextualError(
+                "attempt to store value in unknown secret '%s'" % name
+            )
+        return self.__read_secret(secret)

--- a/vtds_provider_gcp/private/terragrunt/framework/system/project/deploy/inputs.yaml
+++ b/vtds_provider_gcp/private/terragrunt/framework/system/project/deploy/inputs.yaml
@@ -27,6 +27,7 @@ activate_extra_apis:
   - "servicenetworking.googleapis.com"
   - "storage-api.googleapis.com"
   - "networkmanagement.googleapis.com"
+  - "secretmanager.googleapis.com"
 disable_dependent_services: false
 disable_services_on_destroy: false
 labels: { contact: "vtds-team", team: "vtds", role: "vtds-support" }

--- a/vtds_provider_gcp/provider.py
+++ b/vtds_provider_gcp/provider.py
@@ -125,3 +125,10 @@ class LayerAPI:
 
         """
         return self.private.get_blade_interconnects()
+
+    def get_secrets(self):
+        """Return a Secrets API object that provides access to all
+        available secrets.
+
+        """
+        return self.private.get_secrets()


### PR DESCRIPTION
## Summary and Scope

This PR adds handling of secrets to the provider layer and then goes on to use secrets to add generation and management of SSH keys for direct SSH access to Virtual Blades. 

This is a compatible enhancement.

## Issues and Related PRs

* Resolves [VSHA-599](https://jira-pro.it.hpe.com:8443/browse/VSHA-599)

## Testing

### Tested on:

  * Virtual Shasta (vTDS)

### Test description:

Deployed vTDS using the vtds-provider-gcp layer implementation. Verified that SSH keys were stored in the correct secret, verified that SSH keys were authorized on the Virtual Blades.

## Risks and Mitigations

There are no known risks associated with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ N/A ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

