### PR TITLE
Add Secrets, Connections and Abstract Copy and Run Operations

### DIFF
--- a/vtds_provider_gcp/api_objects.py
+++ b/vtds_provider_gcp/api_objects.py
@@ -72,6 +72,26 @@ class VirtualBlades(metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def blade_ssh_key_secret(self, blade_type):
+        """Return the name of the secret containing the SSH key pair
+        used to to authenticate with blades of the specified blade
+        type.
+
+        """
+
+    @abstractmethod
+    def blade_ssh_key_paths(self, blade_type):
+        """Return a tuple of paths to files containing the public and
+        private SSH keys used to to authenticate with blades of the
+        specified blade type. The tuple is in the form '(public_path,
+        private_path)' The value of 'private_path' is suitable for use
+        with the '-i' option of 'ssh'. Before returning this call will
+        verify that both files can be opened for reading and will fail
+        with a ContextualError if either cannot.
+
+        """
+
+    @abstractmethod
     @contextmanager
     def connect_blade(self, remote_port, blade_type, instance):
         """Establish an external connection to the specified remote

--- a/vtds_provider_gcp/api_objects.py
+++ b/vtds_provider_gcp/api_objects.py
@@ -93,7 +93,7 @@ class VirtualBlades(metaclass=ABCMeta):
 
     @abstractmethod
     @contextmanager
-    def connect_blade(self, remote_port, blade_type, instance):
+    def connect_blade(self, blade_type, instance, remote_port):
         """Establish an external connection to the specified remote
         port on the specified instance of the named Virtual Blade
         type. Return a context manager (suitable for use in a 'with'
@@ -106,6 +106,32 @@ class VirtualBlades(metaclass=ABCMeta):
     @contextmanager
     @abstractmethod
     def connect_blades(self, remote_port, blade_types=None):
+        """Establish external connections to the specified remote port
+        on all the Virtual Blade instances on all the Virtual Blade
+        types listed by name in 'blade_types'. If 'blade_types' is not
+        provided or None, all available blade types are used. Return a
+        context manager (suitable for use in a 'with' clause) yielding
+        the list of APIBladeConnection objects representing the
+        connections. Upon leaving the 'with' context, all the
+        connections in the resulting list are closed.
+
+        """
+
+    @abstractmethod
+    @contextmanager
+    def ssh_connect_blade(self, blade_type, instance, remote_port):
+        """Establish an external connection to the SSH server
+        port on the specified instance of the named Virtual Blade
+        type. Return a context manager (suitable for use in a 'with'
+        clause) yielding a BladeSSHConnection object for the
+        connection. Upon leaving the 'with' context, the connection in
+        the BladeSSHConnection is closed.
+
+        """
+
+    @contextmanager
+    @abstractmethod
+    def ssh_connect_blades(self, remote_port=22, blade_types=None):
         """Establish external connections to the specified remote port
         on all the Virtual Blade instances on all the Virtual Blade
         types listed by name in 'blade_types'. If 'blade_types' is not
@@ -166,6 +192,198 @@ class BladeConnection(metaclass=ABCMeta):
     def local_port(self):
         """Return the TCP port number on the locally reachable IP
         address of the connection to the Virtual Blade.
+
+        """
+
+    @abstractmethod
+    def remote_port(self):
+        """Return the TCP port number on the on the Virtual blade to
+        which the BladeConnection connects.
+
+        """
+
+
+class BladeConnectionSet(metaclass=ABCMeta):
+    """A class that contains multiple active BladeConnections to
+    facilitate operations on multiple simultaneous blades. This class
+    is just a wrapper for a list of BladeContainers and should be
+    obtained using the VirtualBlades.connect_blades() method not
+    directly.
+
+    """
+    @abstractmethod
+    def list_connections(self, blade_type=None):
+        """List the connections in the BladeConnectionSet filtered by
+        'blade_type' if that is present. Otherwise imply list all of
+        the connections.
+
+        """
+
+    @abstractmethod
+    def get_connection(self, hostname):
+        """Return the connection corresponding to the specified
+        VirtualBlade hostname ('hostname') or None if the hostname is
+        not found.
+
+        """
+
+
+class BladeSSHConnection(BladeConnection, metaclass=ABCMeta):
+    """Specifically a connection to the SSH server on a blade (remote
+    port 22 unless otherwise specified) with methods to copy files to
+    and from the blade using SCP and to run commands on the blade
+    using SSH.
+
+    """
+    @abstractmethod
+    def copy_to(
+        self, source, destination,
+        blocking=True, logfiles=None, **kwargs
+    ):
+        """Copy a file from a path on the local machine ('source') to
+        a path on the virtual blade ('dest'). The SCP operation is run
+        under a subprocess.Popen() object, which is returned at the
+        end of the call. If additional keyword arguments are supplied,
+        they may be used to override defaults set up by this function
+        and passed to subprocess.Popen() or simply passed on to
+        subprocess.Popen() as keyword arguments.
+
+        If the 'logfiles' argument is provided, it contains a two
+        element tuple telling run_command where to put standard output
+        and standard error logging for the copy respectively.
+        Normally, these are specified as pathnames to log
+        files. Either or both can also be a file object or None. If a
+        file object is used, the output is written to the file. If
+        None is used, the corresponding output is not redirected and
+        the default Popen() behavior is used.
+
+        If the 'async' option is False (default), copy_to() will block
+        waiting for the copy to complete (or fail) and raise a
+        ContextualError exception if it fails. If the 'async' option
+        is True, copy_to() will return immediately once the Popen()
+        object is created and let the caller manage the sub-process.
+
+        """
+
+    @abstractmethod
+    def copy_from(
+            self, source, destination, blocking=True, logfiles=None, **kwargs
+    ):
+        """Copy a file from a path on the blade ('source') to a path
+        on the local machine ('dest'). The SCP operation is run under
+        a subprocess.Popen() object, which is returned at the end of
+        the call. If additional keyword arguments are supplied, they
+        may be used to override defaults set up by this function and
+        passed to subprocess.Popen() or simply passed on to
+        subprocess.Popen() as keyword arguments.
+
+        If the 'logfiles' argument is provided, it contains a two
+        element tuple telling run_command where to put standard output
+        and standard error logging for the copy respectively.
+        Normally, these are specified as pathnames to log
+        files. Either or both can also be a file object or None. If a
+        file object is used, the output is written to the file. If
+        None is used, the corresponding output is not redirected and
+        the default Popen() behavior is used.
+
+        If the 'blocking' option is True (default), copy_from() will
+        block waiting for the copy to complete (or fail) and raise a
+        ContextualError exception if it fails. If the 'blocking' option
+        is False, copy_from() will return immediately once the Popen()
+        object is created and let the caller manage the sub-process.
+
+        """
+
+    @abstractmethod
+    def run_command(self, cmd, blocking=True, logfiles=None, **kwargs):
+        """Using SSH, run the command in the string 'cmd' on the
+        blade. The string 'cmd' can be templated using Jinja
+        templating to use any of the attributes of the underlying
+        connection:
+
+        - the blade type: 'blade_type'
+        - the blade hostname: 'blade_hostname'
+        - the connection port on the blade: 'remote_port'
+        - the local connection IP address: 'local_ip'
+        - the local connection port: 'local_port'
+
+        The resulting command will be executed by the shell on the
+        blade under an SSH session by creating a subprocess.Popen()
+        object. If additional keyword arguments are supplied, they may
+        be used to override defaults set up by this function and
+        passed to subprocess.Popen() or simply passed on to
+        subprocess.Popen() as keyword arguments.
+
+        If the 'logfiles' argument is provided, it contains a two
+        element tuple telling run_command where to put standard output
+        and standard error logging for the command respectively.
+        Normally, these are specified as pathnames to log
+        files. Either or both can also be a file object or None. If a
+        file object is used, the output is written to the file. If
+        None is used, the corresponding output is not redirected and
+        the default Popen() behavior is used.
+
+        If the 'blocking' option is False (default), run_command() will
+        block waiting for the command to complete (or fail) and raise
+        a ContextualError exception if it fails. If the 'blocking' option
+        is False, run_command() will return immediately once the
+        Popen() object is created and let the caller manage the
+        sub-process.
+
+        """
+
+
+class BladeSSHConnectionSet(BladeConnectionSet, metaclass=ABCMeta):
+    """A class to wrap multiple BladeSSHConnections and provide
+    operations that run in parallel across multiple connections.
+
+    """
+    @abstractmethod
+    def copy_to(self, source, destination, logname=None, blade_type=None):
+        """Copy the file at a path on the local machine ('source') to
+        a path ('dest') on all of the selected blades (based on
+        'blade_type'). If 'blade_type is not specified or None, copy
+        the file to all connected blades. Wait until all copies
+        complete or fail. If any of the copies fail, collect the
+        errors they produce to raise a ContextualError exception
+        describing the failures.
+
+        If the 'logname' argument is provided, use the string found
+        there to compose paths to two files, one that will contain the
+        standard output from the command and one that will contain the
+        standard input. The paths to these files will be included in
+        any error reporting from the operation.
+
+        """
+
+    @abstractmethod
+    def run_command(self, cmd, logname=None, blade_type=None):
+        """Using SSH, run the command in the string 'cmd'
+        asynchronously on all connected blades filtered by
+        'blade_type'. If 'blade_type' is unspecified or None, run on
+        all connected blades. The string 'cmd' can be templated using
+        Jinja templating to use any of the attributes of the
+        underlying connection. In this case, the connection in which
+        the command is being run will be used for the templating, so,
+        for example, 'blade_hostname' will match the blade on which
+        the command runs:
+
+        - the blade type: 'blade_type'
+        - the blade instance within its type: 'instance'
+        - the blade hostname: 'blade_hostname'
+        - the connection port on the blade: 'remote_port'
+        - the local connection IP address: 'local_ip'
+        - the local connection port: 'local_port'
+
+        Wait until all commands complete or fail. If any of the
+        commands fail, collect the errors they produce to raise a
+        ContextualError exception describing the failures.
+
+        If the 'logname' argument is provided, use the string found
+        there to compose paths to two files, one that will contain the
+        standard output from the command and one that will contain the
+        standard input. The paths to these files will be included in
+        any error reporting from the operation.
 
         """
 

--- a/vtds_provider_gcp/private/api_objects.py
+++ b/vtds_provider_gcp/private/api_objects.py
@@ -24,7 +24,10 @@
 
 """
 from contextlib import contextmanager
-from subprocess import Popen
+from subprocess import (
+    Popen,
+    TimeoutExpired
+)
 from socketserver import TCPServer
 from socket import (
     socket,
@@ -32,6 +35,10 @@ from socket import (
     SOCK_STREAM
 )
 from time import sleep
+from jinja2 import (
+    Template,
+    TemplateError
+)
 
 from vtds_base import (
     ContextualError,
@@ -43,6 +50,9 @@ from ..api_objects import (
     VirtualBlades,
     BladeInterconnects,
     BladeConnection,
+    BladeConnectionSet,
+    BladeSSHConnection,
+    BladeSSHConnectionSet,
     Secrets
 )
 
@@ -124,7 +134,7 @@ class PrivateVirtualBlades(VirtualBlades):
         return self.common.ssh_key_paths(secret_name)
 
     @contextmanager
-    def connect_blade(self, remote_port, blade_type, instance):
+    def connect_blade(self, blade_type, instance, remote_port):
         """Establish an external connection to the specified remote
         port on the specified instance of the named Virtual Blade
         type. Return a context manager (suitable for use in a 'with'
@@ -150,7 +160,7 @@ class PrivateVirtualBlades(VirtualBlades):
         types listed by name in 'blade_types'. If 'blade_types' is not
         provided or None, all available blade types are used. Return a
         context manager (suitable for use in a 'with' clause) yielding
-        the list of APIBladeConnection objects representing the
+        the list of BladeConnection objects representing the
         connections. Upon leaving the 'with' context, all the
         connections in the resulting list are closed.
 
@@ -166,7 +176,61 @@ class PrivateVirtualBlades(VirtualBlades):
             for instance in range(0, self.blade_count(blade_type))
         ]
         try:
-            yield connections
+            yield PrivateBladeConnectionSet(self.common, connections)
+        finally:
+            for connection in connections:
+                # This is a layer private operation not really class
+                # private. Treat this reference as friendly.
+                connection._disconnect()  # pylint: disable=protected-access
+
+    @contextmanager
+    def ssh_connect_blade(self, blade_type, instance, remote_port=22):
+        """Establish an external connection to the SSH server on the
+        specified instance of the named Virtual Blade type. Return a
+        context manager (suitable for use in a 'with' clause) yielding
+        a BladeSSHConnection object for the connection. Upon leaving the
+        'with' context, the connection in the BladeSSHConnection is
+        closed.
+
+        """
+        connection = PrivateBladeSSHConnection(
+            self.common, blade_type, instance,
+            self.blade_ssh_key_paths(blade_type)[1],
+            remote_port
+        )
+        try:
+            yield connection
+        finally:
+            # This is a layer private operation not really class
+            # private. Treat this reference as friendly.
+            connection._disconnect()  # pylint: disable=protected-access
+
+    @contextmanager
+    def ssh_connect_blades(self, remote_port=22, blade_types=None):
+        """Establish external connections to the SSH server on all the
+        Virtual Blade instances on all the Virtual Blade types listed
+        by name in 'blade_types'. If 'blade_types' is not provided or
+        None, all available blade types are used. Return a context
+        manager (suitable for use in a 'with' clause) yielding a
+        BladeSSHConnectionSet object representing the
+        connections. Upon leaving the 'with' context, all the
+        connections create are closed.
+
+        """
+        blade_types = (
+            self.blade_types() if blade_types is None else blade_types
+        )
+        connections = [
+            PrivateBladeSSHConnection(
+                self.common, blade_type, instance,
+                self.blade_ssh_key_paths(blade_type)[1],
+                remote_port
+            )
+            for blade_type in blade_types
+            for instance in range(0, self.blade_count(blade_type))
+        ]
+        try:
+            yield PrivateBladeSSHConnectionSet(self.common, connections)
         finally:
             for connection in connections:
                 # This is a layer private operation not really class
@@ -236,7 +300,6 @@ class PrivateBladeInterconnects(BladeInterconnects):
         return interconnect['ipv4_cidr']
 
 
-# pylint: disable=invalid-name
 class PrivateBladeConnection(BladeConnection):
     """A class containing the relevant information needed to use
     external connections to ports on a specific Virtual Blade.
@@ -386,6 +449,13 @@ class PrivateBladeConnection(BladeConnection):
         """
         return self.hostname
 
+    def remote_port(self):
+        """Return the TCP port number on the on the Virtual blade to
+        which the BladeConnection connects.
+
+        """
+        return self.rem_port
+
     def local_ip(self):
         """Return the locally reachable IP address of the connection
         to the Virtual Blade.
@@ -399,6 +469,496 @@ class PrivateBladeConnection(BladeConnection):
 
         """
         return self.loc_port
+
+
+class PrivateBladeConnectionSet(BladeConnectionSet):
+    """A class that contains multiple active BladeConnections to
+    facilitate operations on multiple simultaneous blades. This class
+    is just a wrapper for a list of BladeContainers and should be
+    obtained using the VirtualBlades.connect_blades() method not
+    directly.
+
+    """
+    def __init__(self, common, blade_connections):
+        """Constructor
+
+        """
+        self.common = common
+        self.blade_connections = blade_connections
+
+    def list_connections(self, blade_type=None):
+        """List the connections in the BladeConnectionSet filtered by
+        'blade_type' if that is present. Otherwise imply list all of
+        the connections.
+
+        """
+        return [
+            blade_connection for blade_connection in self.blade_connections
+            if blade_type is None or
+            blade_connection.blade_type() == blade_type
+        ]
+
+    def get_connection(self, hostname):
+        """Return the connection corresponding to the specified
+        VirtualBlade hostname ('hostname') or None if the hostname is
+        not found.
+
+        """
+        for blade_connection in self.blade_connections:
+            if blade_connection.blade_hostname == hostname:
+                return blade_connection
+        return None
+
+
+# The following is shared by PrivateBladeSSHConnection and
+# PrivateBladeSSHConnectionSet. This should be treaded as private to
+# this file. It is pulled out of both classes for easy sharing.
+def wait_for_popen(subprocess, cmd, logpaths, timeout=None, **kwargs):
+    """Wait for a Popen() object to reach completion and return
+    the exit value.
+
+    If 'check' is either omitted from the keyword arguments or is
+    supplied in the keyword aguments and True, raise a
+    ContextualError if the command exists with a non-zero exit
+    value, otherwise simply return the exit value.
+
+    If 'timeout' is supplied (in seconds) and exceeded kill the
+    Popen() object and then raise a ContextualError indicating the
+    timeout and reporting where the command logs can be found.
+
+    """
+    info_msg(
+        "waiting for popen: "
+        "subproc='%s', cmd='%s', logpaths='%s', timeout='%s', kwargs='%s'" % (
+            str(subprocess), str(cmd), str(logpaths), str(timeout), str(kwargs)
+        )
+    )
+    check = kwargs.get('check', True)
+    time = timeout if timeout is not None else 0
+    signaled = False
+    while True:
+        try:
+            exitval = subprocess.wait(timeout=5)
+            break
+        except TimeoutExpired:
+            time -= 5 if timeout is not None else 0
+            if timeout is not None and time <= 0:
+                if not signaled:
+                    # First try to terminate the process
+                    subprocess.terminate()
+                    continue
+                subprocess.kill()
+                # pylint: disable=raise-missing-from
+                raise ContextualError(
+                    "SSH command '%s' timed out and did not terminate "
+                    "as expected after %d seconds" % (str(cmd), time),
+                    *logpaths
+                )
+            continue
+    if check and exitval != 0:
+        raise ContextualError(
+            "SSH command '%s' terminated with a non-zero "
+            "exit status '%d'" % (str(cmd), exitval),
+            *logpaths
+        )
+    return exitval
+
+
+class PrivateBladeSSHConnection(BladeSSHConnection, PrivateBladeConnection):
+    """Specifically a connection to the SSH server on a blade (remote
+    port 22 unless otherwise specified) with methods to copy files to
+    and from the blade using SCP and to run commands on the blade
+    using SSH.
+
+    """
+    def __init__(
+        self,
+        common, blade_type, instance,  private_key_path, remote_port=22,
+        **kwargs
+    ):
+        PrivateBladeConnection.__init__(
+            self,
+            common, blade_type, instance, remote_port
+        )
+        default_opts = [
+            '-o', 'BatchMode=yes',
+            '-o', 'NoHostAuthenticationForLocalhost=yes',
+            '-o', 'StrictHostKeyChecking=no',
+        ]
+        port_opt = [
+            '-o', 'Port=%s' % str(self.loc_port),
+        ]
+        self.options = kwargs.get('options', default_opts)
+        self.options += port_opt
+        self.private_key_path = private_key_path
+
+    def __run(
+        self, cmd, blocking=True, out_path=None, err_path=None,  **kwargs
+    ):
+        """Run an arbitrary command under Popen() either synchronously
+        or asynchronously letting exceptions bubble up to the caller.
+
+        """
+        with logfile(out_path) as out_file, logfile(err_path) as err_file:
+            if blocking:
+                with Popen(
+                        cmd,
+                        stdout=out_file, stderr=err_file,
+                        **kwargs
+                ) as subprocess:
+                    return wait_for_popen(
+                        subprocess, cmd, (out_path, err_path), None, **kwargs
+                    )
+            else:
+                return Popen(
+                    cmd,
+                    stdout=out_file, stderr=err_file,
+                    **kwargs
+                )
+
+    def _render_cmd(self, cmd):
+        """Layer private: render the specified command string with
+        Jinja to fill in the BladeSSHConnection specific data in a
+        templated command.
+
+        """
+        jinja_values = {
+            'blade_type': self.b_type,
+            'instance': self.instance,
+            'blade_hostname': self.hostname,
+            'remote_port': self.rem_port,
+            'local_ip': self.loc_ip,
+            'local_port': self.loc_port
+        }
+        try:
+            template = Template(cmd)
+            return template.render(**jinja_values)
+        except TemplateError as err:
+            raise ContextualError(
+                "error using Jinja to render command line '%s' - %s" % (
+                    cmd,
+                    str(err)
+                )
+            ) from err
+
+    def copy_to(
+        self, source, destination, blocking=True, logfiles=None, **kwargs
+    ):
+        """Copy a file from a path on the local machine ('source') to
+        a path on the virtual blade ('dest'). The SCP operation is run
+        under a subprocess.Popen() object, which is returned at the
+        end of the call. If additional keyword arguments are supplied,
+        they may be used to override defaults set up by this function
+        and passed to subprocess.Popen() or simply passed on to
+        subprocess.Popen() as keyword arguments.
+
+        If the 'logfiles' argument is provided, it contains a two
+        element tuple telling run_command where to put standard output
+        and standard error logging for the copy respectively.
+        Normally, these are specified as pathnames to log
+        files. Either or both can also be a file object or None. If a
+        file object is used, the output is written to the file. If
+        None is used, the corresponding output is not redirected and
+        the default Popen() behavior is used.
+
+        If the 'blocking' option is True (default), copy_to() will
+        block waiting for the copy to complete (or fail) and raise a
+        ContextualError exception if it fails. If the 'blocking'
+        option is False, copy_to() will return immediately once the
+        Popen() object is created and let the caller manage the
+        sub-process.
+
+        """
+        logfiles = logfiles if logfiles is not None else (None, None)
+        cmd = [
+            'scp', '-i', self.private_key_path, *self.options,
+            source,
+            'root@%s:%s' % (self.loc_ip, destination)
+        ]
+        try:
+            return self.__run(cmd, blocking, *logfiles, **kwargs)
+        except ContextualError:
+            # If it is one of ours just send it on its way to be handled
+            raise
+        except Exception as err:
+            # Not one of ours, turn it into one of ours
+            raise ContextualError(
+                "failed to copy file '%s' to 'root@%s:%s' "
+                "using command: %s - %s" % (
+                    source, self.hostname, destination, str(cmd), str(err)
+                ),
+                *logfiles
+            ) from err
+
+    def copy_from(
+        self, source, destination, blocking=True, logfiles=None, **kwargs
+    ):
+        """Copy a file from a path on the blade ('source') to a path
+        on the local machine ('dest'). The SCP operation is run under
+        a subprocess.Popen() object, which is returned at the end of
+        the call. If additional keyword arguments are supplied, they
+        may be used to override defaults set up by this function and
+        passed to subprocess.Popen() or simply passed on to
+        subprocess.Popen() as keyword arguments.
+
+        If the 'logfiles' argument is provided, it contains a two
+        element tuple telling run_command where to put standard output
+        and standard error logging for the copy respectively.
+        Normally, these are specified as pathnames to log
+        files. Either or both can also be a file object or None. If a
+        file object is used, the output is written to the file. If
+        None is used, the corresponding output is not redirected and
+        the default Popen() behavior is used.
+
+        If the 'blocking' option is True (default), copy_from() will
+        block waiting for the copy to complete (or fail) and raise a
+        ContextualError exception if it fails. If the 'blocking'
+        option is False, copy_from() will return immediately once the
+        Popen() object is created and let the caller manage the
+        sub-process.
+
+        """
+        logfiles = logfiles if logfiles is not None else (None, None)
+        cmd = [
+            'scp', '-i', self.private_key_path, *self.options,
+            'root@%s:%s' % (self.loc_ip, destination),
+            source
+        ]
+        try:
+            return self.__run(cmd, blocking, *logfiles, **kwargs)
+        except ContextualError:
+            # If it is one of ours just send it on its way to be handled
+            raise
+        except Exception as err:
+            # Not one of ours, turn it into one of ours
+            raise ContextualError(
+                "failed to copy file '%s' from 'root@%s:%s' "
+                "using command: %s - %s" % (
+                    destination, self.hostname, source, str(cmd), str(err)
+                ),
+                *logfiles,
+            ) from err
+
+    def run_command(self, cmd, blocking=True, logfiles=None, **kwargs):
+        """Using SSH, run the command in the string 'cmd'
+        asynchronously on the blade. The string 'cmd' can be templated
+        using Jinja templating to use any of the attributes of the
+        underlying connection:
+
+        - the blade type: 'blade_type'
+        - the blade instance within its type: 'instance'
+        - the blade hostname: 'blade_hostname'
+        - the connection port on the blade: 'remote_port'
+        - the local connection IP address: 'local_ip'
+        - the local connection port: 'local_port'
+
+        The resulting command will be executed by the shell on the
+        blade under an SSH session by creating a subprocess.Popen()
+        object. If additional keyword arguments are supplied, they may
+        be used to override defaults set up by this function and
+        passed to subprocess.Popen() or simply passed on to
+        subprocess.Popen() as keyword arguments.
+
+        If the 'logfiles' argument is provided, it contains a two
+        element tuple telling run_command where to put standard output
+        and standard error logging for the command respectively.
+        Normally, these are specified as pathnames to log
+        files. Either or both can also be a file object or None. If a
+        file object is used, the output is written to the file. If
+        None is used, the corresponding output is not redirected and
+        the default Popen() behavior is used.
+
+        If the 'blocking' option is True (default), run_command() will
+        block waiting for the command to complete (or fail) and raise
+        a ContextualError exception if it fails. If the 'blocking'
+        option is False, run_command() will return immediately once the
+        Popen() object is created and let the caller manage the
+        sub-process.
+
+        """
+        cmd = self._render_cmd(cmd)
+        logfiles = logfiles if logfiles is not None else (None, None)
+        ssh_cmd = [
+            'ssh', '-i', self.private_key_path, *self.options,
+            'root@%s' % (self.loc_ip), cmd
+        ]
+        try:
+            return self.__run(ssh_cmd, blocking, *logfiles, **kwargs)
+        except ContextualError:
+            # If it is one of ours just send it on its way to be handled
+            raise
+        except Exception as err:
+            # Not one of ours, turn it into one of ours
+            raise ContextualError(
+                "failed to run command '%s' on '%s' - %s" % (
+                    cmd, self.hostname, str(err)
+                ),
+                *logfiles
+            ) from err
+
+
+class PrivateBladeSSHConnectionSet(
+        BladeSSHConnectionSet, PrivateBladeConnectionSet
+):
+    """A class to wrap multiple BladeSSHConnections and provide
+    operations that run in parallel across multiple connections.
+
+    """
+    def __init__(self, common, connections):
+        """Constructor
+        """
+        PrivateBladeConnectionSet.__init__(self, common, connections)
+
+    def copy_to(self, source, destination, logname=None, blade_type=None):
+        """Copy the file at a path on the local machine ('source') to
+        a path ('dest') on all of the selected blades (based on
+        'blade_type'). If 'blade_type is not specified or None, copy
+        the file to all connected blades. Wait until all copies
+        complete or fail. If any of the copies fail, collect the
+        errors they produce to raise a ContextualError exception
+        describing the failures.
+
+        If the 'logname' argument is provided, use the string found
+        there to compose the 'logfiles' argument to be passed to each
+        copy operation.
+
+        """
+        logname = (
+            logname if logname is not None else
+            "parallel-copy-to-%s-%s" % (source, destination)
+        )
+        # Okay, this is big and weird. It composes the arguments to
+        # pass to wait_for_popen() for each copy operation. Note
+        # that, normally, the 'cmd' argument in wait_for_popen() is
+        # the Popen() 'cmd' argument (i.e. a list of command
+        # compoinents. Here it is simply a descriptive string. This is
+        # okay because wait_for_popen() only uses that information
+        # for error generation.
+        wait_args_list = [
+            (
+                blade_connection.copy_to(
+                    source, destination, False,
+                    log_paths(
+                        self.common.build_dir(),
+                        "%s-%s" % (logname, blade_connection.blade_hostname())
+                    )
+                ),
+                "scp %s to root@%s:%s" % (
+                    source,
+                    blade_connection.blade_hostname(),
+                    destination
+                ),
+                log_paths(
+                    self.common.build_dir(),
+                    "%s-%s" % (logname, blade_connection.blade_hostname())
+                )
+            )
+            for blade_connection in self.blade_connections
+            if blade_type is None or
+            blade_connection.blade_type() == blade_type
+        ]
+        # Go through all of the copy operations and collect (if
+        # needed) any errors that are raised by
+        # wait_for_popen(). This acts as a barrier, so when we are
+        # done, we know all of the copies have completed.
+        errors = []
+        for wait_args in wait_args_list:
+            try:
+                wait_for_popen(*wait_args)
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                errors.append(str(err))
+        if errors:
+            raise ContextualError(
+                "errors reported while copying '%s' to '%s' on %s\n"
+                "    %s" % (
+                    source,
+                    destination,
+                    "all Virtual Blades" if blade_type is None else
+                    "Virtual Blades of type %s" % blade_type,
+                    "\n\n    ".join(errors)
+                )
+            )
+
+    def run_command(self, cmd, logname=None, blade_type=None):
+        """Using SSH, run the command in the string 'cmd'
+        asynchronously on all connected blades filtered by
+        'blade_type'. If 'blade_type' is unspecified or None, run on
+        all connected blades. The string 'cmd' can be templated using
+        Jinja templating to use any of the attributes of the
+        underlying connection. In this case, the connection in which
+        the command is being run will be used for the templating, so,
+        for example, 'blade_hostname' will match the blade on which
+        the command runs:
+
+        - the blade type: 'blade_type'
+        - the blade hostname: 'blade_hostname'
+        - the connection port on the blade: 'remote_port'
+        - the local connection IP address: 'local_ip'
+        - the local connection port: 'local_port'
+
+        Wait until all commands complete or fail. If any of the
+        commands fail, collect the errors they produce to raise a
+        ContextualError exception describing the failures.
+
+        If the 'logname' argument is provided, use the string found
+        there to compose paths to two files, one that will contain the
+        standard output from the command and one that will contain the
+        standard input. The paths to these files will be included in
+        any error reporting from the operation.
+
+        """
+        logname = (
+            logname if logname is not None else
+            "parallel-run-%s" % (cmd.split()[0])
+        )
+        # Okay, this is big and weird. It composes the arguments to
+        # pass to wait_for_popen() for each copy operation. Note
+        # that, normally, the 'cmd' argument in wait_for_popen() is
+        # the Popen() 'cmd' argument. Here is is simply the shell
+        # command being run under SSH. This is okay because
+        # wait_for_popen() only uses that information for error
+        # generation.
+        wait_args_list = [
+            (
+                blade_connection.run_command(
+                    cmd, False,
+                    log_paths(
+                        self.common.build_dir(),
+                        "%s-%s" % (logname, blade_connection.blade_hostname())
+                    )
+                ),
+                cmd,
+                log_paths(
+                    self.common.build_dir(),
+                    "%s-%s" % (logname, blade_connection.blade_hostname())
+                )
+            )
+            for blade_connection in self.blade_connections
+            if blade_type is None or
+            blade_connection.blade_type() == blade_type
+        ]
+        # Go through all of the copy operations and collect (if
+        # needed) any errors that are raised by
+        # wait_for_popen(). This acts as a barrier, so when we are
+        # done, we know all of the copies have completed.
+        errors = []
+        for wait_args in wait_args_list:
+            try:
+                wait_for_popen(*wait_args)
+            # pylint: disable=broad-exception-caught
+            except Exception as err:
+                errors.append(str(err))
+        if errors:
+            raise ContextualError(
+                "errors reported running command '%s' on %s\n"
+                "    %s" % (
+                    cmd,
+                    "all Virtual Blades" if blade_type is None else
+                    "Virtual Blades of type %s" % blade_type,
+                    "\n\n    ".join(errors)
+                )
+            )
 
 
 class PrivateSecrets(Secrets):

--- a/vtds_provider_gcp/private/common.py
+++ b/vtds_provider_gcp/private/common.py
@@ -163,10 +163,12 @@ class Common:
                 '--format=value(PROJECT_ID)'
             ],
             log_paths(self.build_directory, "common-get-project-id"),
-            stdout=PIPE
+            stdout=PIPE,
+            check=False
         )
         # Reference the class variable using the class name to set it.
         Common.project_id = result.stdout.rstrip()
+        Common.project_id = Common.project_id if Common.project_id else None
         return self.project_id
 
     def get_zone(self):

--- a/vtds_provider_gcp/private/config/config.yaml
+++ b/vtds_provider_gcp/private/config/config.yaml
@@ -386,7 +386,14 @@ provider:
       gpu: null
       resource_policies: []
   secrets:
-    blade_ssh_keys:
+    # All of the secrets to be used in your vTDS system are declared
+    # here, though their values and use may come from other
+    # layers. Secrets declared here will be created within the GCP
+    # Secret Manager and available for storing into or reading out of
+    # by name through the Secrets API object. Binding of secrets to
+    # other objects in the configuration is done using the name in the
+    # 'name' field of the secret.
+    blade_ssh_key:
       # The SSH public / private key pair used by the provider layer
       # to talk to Virtual Blades. The public key will be added to
       # '/root/.ssh/authorized_keys' upon deployment of virtual
@@ -396,9 +403,9 @@ provider:
       # its function. Generally not used, but here if you want it. No
       # more than 64 labels can be assigned.
       labels: {}
-      # Key value pairs, similar to labels. There will always be
-      # a 'layer' annotation indicating what layer requested creation
-      # of the secret. The total size of annotation keys and values
-      # must be less than 16KiB.
+      # Key value pairs, similar to labels. There will always be a
+      # 'layer' annotation indicating what layer provides the secret
+      # value. The total size of annotation keys and values must be
+      # less than 16KiB.
       annotations:
         layer: provider

--- a/vtds_provider_gcp/private/private_provider.py
+++ b/vtds_provider_gcp/private/private_provider.py
@@ -27,7 +27,6 @@ from os.path import dirname
 from os import makedirs
 from shutil import rmtree
 from yaml import (
-    YAMLError,
     safe_load,
     safe_dump
 )
@@ -73,14 +72,29 @@ class PrivateProvider:
         self.stack = stack
         self.prepared = False
 
-    def __populate_blade_ssh_secret(self, secret_name):
-        """Set up an SSH key pair and store it in the named secret.
+    def __read_key_secrets(self, secret_name):
+        """Read SSH keys back from an SSH keys directory in the build
+        tree based on the SSH key secret name for the secret that
+        holds the keys.
 
         """
         pub_key, priv_key = self.common.ssh_key_paths(secret_name, True)
-        ssh_dir = dirname(priv_key)
+        # Read back the keys into a dictionary to return to the caller
+        with open(priv_key, 'r', encoding='UTF-8') as private, \
+             open(pub_key, 'r', encoding='UTF-8') as public:
+            keys = {
+                'private': private.read().rstrip(),
+                'public': public.read().rstrip(),
+            }
+        return keys
 
+    def __generate_blade_ssh_keys(self, secret_name):
+        """Set up an SSH key pair and store it in the named secret.
+
+        """
         # Make sure there is a fresh empty directory in place for the keys.
+        _, priv_key = self.common.ssh_key_paths(secret_name, True)
+        ssh_dir = dirname(priv_key)
         rmtree(ssh_dir, ignore_errors=True)
         makedirs(ssh_dir, mode=0o700, exist_ok=True)
 
@@ -89,95 +103,54 @@ class PrivateProvider:
             ['ssh-keygen', '-q', '-N', '', '-t', 'rsa', '-f', priv_key],
             log_paths(self.common.build_dir(), "make-ssh-key-%s" % secret_name)
         )
+        return self.__read_key_secrets(secret_name)
 
-        # Stash the keys in the secret
-        with open(priv_key, 'r', encoding='UTF-8') as private, \
-             open(pub_key, 'r', encoding='UTF-8') as public:
-            keys = {
-                'private': private.read(),
-                'public': public.read(),
-            }
-        secret = safe_dump(keys)
-        self.secret_manager.store(secret_name, secret)
-
-    def __authorize_blade_ssh_secret(self, secret_name):
-        """For all blades using the specified secret as their SSH key,
-        add the public key to the 'root' '.ssh/authorized_keys'
-        contents.
+    def __add_ssh_key(self, blade_type, blade_config):
+        """Add the SSH public key from the blade's ssh_key_secret to
+        the blade metadata so that when the blade is deployed it will
+        have the proper authorized key for SSH access through a blade
+        connection.
 
         """
-        data = self.secret_manager.read(secret_name)
-        if data is None:
+        secret_name = blade_config.get("ssh_key_secret", None)
+        if secret_name is None:
             raise ContextualError(
-                "SSH key for secret '%s' is not yet populated" % secret_name
+                "provider config error: no 'ssh_key_secret' "
+                "found in blade type '%s'" % blade_type
             )
-        try:
-            public_key = safe_load(data)['public']
-        except KeyError as err:
-            raise ContextualError(
-                "data in SSH keys secret '%s' does not contain public key "
-                "field (data not shown to protect secret)" % secret_name
-            ) from err
-        except YAMLError as err:
-            raise ContextualError(
-                "data in SSH keys secret '%s' is not parsable YAML "
-                "(data and error not shown to protect secret)" % secret_name
-            ) from err
-        virtual_blades = self.get_virtual_blades()
-        blades = [
-            (blade_type, instance)
-            for blade_type in virtual_blades.blade_types()
-            if virtual_blades.blade_ssh_key_secret(blade_type) == secret_name
-            for instance in range(0, virtual_blades.blade_count(blade_type))
-        ]
-        project_id = self.common.get_project_id()
-        zone = self.common.get_zone()
-        for blade_type, instance in blades:
-            # Make sure SSH (port 22) is running on the remote
-            # blade. This operation happens early in startup, so it is
-            # necessary to let the blade boot and become ready. A side
-            # effect of connect_blade() is that it waits until it can
-            # establish a connection through the IAP connection before
-            # returning, so this is a good way to achive that ready
-            # wait.
-            virtual_blades.connect_blade(22, blade_type, instance)
-            # Append the public key to 'authorized_keys'
-            hostname = virtual_blades.blade_hostname(blade_type, instance)
-            run(
-                [
-                    'gcloud', 'compute', 'ssh', '--tunnel-through-iap',
-                    '--project=%s' % project_id, '--zone=%s' % zone,
-                    'root@%s' % hostname, '--',
-                    'cat >> /root/.ssh/authorized_keys'
-                ],
-                log_paths(
-                    self.common.build_dir(),
-                    "authorize-%s-on-%s" % (secret_name, hostname)
-                ),
-                input=public_key
-            )
+        secret_data = self.secret_manager.read(secret_name)
+        keys = (
+            safe_load(secret_data)
+            if secret_data is not None
+            else self.__generate_blade_ssh_keys(secret_name)
+        )
+        # This weird little dance makes sure that 'metadata' is in
+        # blade_config and has a sub-KV pair 'metadata' where we can
+        # put the SSH public key(s).
+        blade_config['metadata'] = blade_config.get('metadata', {})
+        blade_config['metadata']['metadata'] = (
+            blade_config['metadata'].get('metadata', {})
+        )
+        public_key = "root:%s\n" % keys['public']
+        blade_config['metadata']['metadata']['ssh-keys'] = public_key
 
-    def __setup_blade_ssh_secrets(self):
-        """For each unique secret used by a Virtual Blade type
-        generate an SSH key pair (in the build tree for temporary
-        storage) and store that key pair in the named secret. On
-        return, there is an SSH key pair stored in each secret, and,
-        for each secret, every blade using that secret has been set up
-        to authorize the public key from that secret.
+    def __create_blade_ssh_secrets(self):
+        """For each unique SSH key secret in the configuration, read
+        in the public and private keys from the build directory data,
+        create a secret of the appropriate name in the project, and
+        store the keys in the secret.
 
         """
         virtual_blades = self.get_virtual_blades()
-        # Get all of the SSH key secret names for all blade types
-        secret_names = [
+        # Get all of the SSH key secret names for all blade types in a
+        # set so they are unique
+        secret_names = {
             virtual_blades.blade_ssh_key_secret(blade_type)
             for blade_type in virtual_blades.blade_types()
-        ]
-        # Coerce the list to a set then back to a list to ensure each
-        # name is unique in the final list.
-        secret_names = list(set(secret_names))
+        }
         for secret_name in secret_names:
-            self.__populate_blade_ssh_secret(secret_name)
-            self.__authorize_blade_ssh_secret(secret_name)
+            keys = self.__read_key_secrets(secret_name)
+            self.secret_manager.store(secret_name, safe_dump(keys))
 
     def prepare(self):
         """Prepare operation. This drives creation of the provider
@@ -192,38 +165,47 @@ class PrivateProvider:
             raise ContextualError(
                 "no virtual blade types found in vTDS provider configuration"
             )
-        for key in blade_types:
+        for blade_type in blade_types:
             # Expand the inheritance tree for the blade type and put
             # the expanded result back into the configuration. That
             # way, when we write out the configuration we have the
             # full expansion there.
-            if blade_types[key].get('pure_base_class', False):
+            if blade_types[blade_type].get('pure_base_class', False):
                 # Skip inheritance and installation for pure base
                 # classes since they have no parents, and they aren't
                 # used for deployment.
                 continue
-            blade_config = expand_inheritance(blade_types, key)
+            blade_config = expand_inheritance(
+                blade_types, blade_type
+            )
             virtual_blade = VirtualBlade(self.terragrunt)
-            blade_config = virtual_blade.initialize(key, blade_config)
-            blade_types[key] = blade_config
+            blade_config = virtual_blade.initialize(
+                blade_type, blade_config
+            )
+            self.__add_ssh_key(blade_type, blade_config)
+            blade_types[blade_type] = blade_config
         interconnect_types = self.common.get('blade_interconnects', None)
         if interconnect_types is None:
             raise ContextualError(
                 "no blade interconnect types found in vTDS provider "
                 "configuration"
             )
-        for key in interconnect_types:
-            if interconnect_types[key].get('pure_base_class', False):
+        for interconnect_type in interconnect_types:
+            if interconnect_types[interconnect_type].get(
+                    'pure_base_class', False
+            ):
                 # Skip inheritance and installation for pure base
                 # classes since they have no parents, and they aren't
                 # used for deployment.
                 continue
-            interconnect_config = expand_inheritance(interconnect_types, key)
+            interconnect_config = expand_inheritance(
+                interconnect_types, interconnect_type
+            )
             blade_interconnect = BladeInterconnect(self.terragrunt)
             interconnect_config = blade_interconnect.initialize(
-                key, interconnect_config
+                interconnect_type, interconnect_config
             )
-            interconnect_types[key] = interconnect_config
+            interconnect_types[interconnect_type] = interconnect_config
         # Now that we have fully expanded all of the inheritance and
         # set up the terragrunt controls for everything that is going
         # to get them, set up the terragrunt configuration.
@@ -258,7 +240,7 @@ class PrivateProvider:
             )
         self.terragrunt.deploy()
         self.secret_manager.deploy()
-        self.__setup_blade_ssh_secrets()
+        self.__create_blade_ssh_secrets()
 
     def shutdown(self, virtual_blade_names):
         """Shutdown operation. This will shut down (power off) the


### PR DESCRIPTION
## Summary and Scope

Add the ability to handle secrets in the provider layer and also implement Blade Connections and Blade SSH Connections as part of the Provider API. Blade SSH connections implement abstracted "copy to", "copy from and "run command" operations that permit other layers to access blades through SSH without the need to manage the subprocesses in detail.

Backward compatible feature.

## Testing

Deployed and removed systems up through the platform layer to verify that all of the new functionality works and that the existing functionality was not broken.

Tested on Virtual Shasta (vTDS)

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

There are no known risks associated with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ N/A ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

