### PR TITLE
Fix issues with 'recurse' option to copy-to and copy from

### DIFF
--- a/vtds_provider_gcp/api_objects.py
+++ b/vtds_provider_gcp/api_objects.py
@@ -278,6 +278,10 @@ class BladeSSHConnection(BladeConnection, metaclass=ABCMeta):
         passed to subprocess.Popen() or simply passed on to
         subprocess.Popen() as keyword arguments.
 
+        If the 'recurse' option is True and the local file is a
+        directory, the directory and all of its descendants will be
+        copied.
+
         If the 'logfiles' argument is provided, it contains a two
         element tuple telling run_command where to put standard output
         and standard error logging for the copy respectively.
@@ -340,7 +344,9 @@ class BladeSSHConnectionSet(BladeConnectionSet, metaclass=ABCMeta):
 
     """
     @abstractmethod
-    def copy_to(self, source, destination, logname=None, blade_type=None):
+    def copy_to(
+        self, source, destination, recurse=False, logname=None, blade_type=None
+    ):
         """Copy the file at a path on the local machine ('source') to
         a path ('dest') on all of the selected blades (based on
         'blade_type'). If 'blade_type is not specified or None, copy
@@ -348,6 +354,10 @@ class BladeSSHConnectionSet(BladeConnectionSet, metaclass=ABCMeta):
         complete or fail. If any of the copies fail, collect the
         errors they produce to raise a ContextualError exception
         describing the failures.
+
+        If the 'recurse' option is True and the local file is a
+        directory, the directory and all of its descendants will be
+        copied.
 
         If the 'logname' argument is provided, use the string found
         there to compose paths to two files, one that will contain the

--- a/vtds_provider_gcp/private/api_objects.py
+++ b/vtds_provider_gcp/private/api_objects.py
@@ -675,7 +675,7 @@ class PrivateBladeSSHConnection(BladeSSHConnection, PrivateBladeConnection):
 
         """
         logfiles = logfiles if logfiles is not None else (None, None)
-        recurse_option = ['--recurse'] if recurse else []
+        recurse_option = ['-r'] if recurse else []
         cmd = [
             'scp', '-i', self.private_key_path, *recurse_option, *self.options,
             source,
@@ -730,7 +730,7 @@ class PrivateBladeSSHConnection(BladeSSHConnection, PrivateBladeConnection):
 
         """
         logfiles = logfiles if logfiles is not None else (None, None)
-        recurse_option = ['--recurse'] if recurse else []
+        recurse_option = ['-r'] if recurse else []
         cmd = [
             'scp', '-i', self.private_key_path, *recurse_option, *self.options,
             'root@%s:%s' % (self.loc_ip, destination),
@@ -821,7 +821,10 @@ class PrivateBladeSSHConnectionSet(
         """
         PrivateBladeConnectionSet.__init__(self, common, connections)
 
-    def copy_to(self, source, destination, logname=None, blade_type=None):
+    def copy_to(
+        self, source, destination,
+        recurse=False, logname=None, blade_type=None
+    ):
         """Copy the file at a path on the local machine ('source') to
         a path ('dest') on all of the selected blades (based on
         'blade_type'). If 'blade_type is not specified or None, copy
@@ -829,6 +832,10 @@ class PrivateBladeSSHConnectionSet(
         complete or fail. If any of the copies fail, collect the
         errors they produce to raise a ContextualError exception
         describing the failures.
+
+        If the 'recurse' option is True and the local file is a
+        directory, the directory and all of its descendants will be
+        copied.
 
         If the 'logname' argument is provided, use the string found
         there to compose the 'logfiles' argument to be passed to each
@@ -849,7 +856,7 @@ class PrivateBladeSSHConnectionSet(
         wait_args_list = [
             (
                 blade_connection.copy_to(
-                    source, destination, False,
+                    source, destination, recurse, False,
                     log_paths(
                         self.common.build_dir(),
                         "%s-%s" % (logname, blade_connection.blade_hostname())

--- a/vtds_provider_gcp/private/private_provider.py
+++ b/vtds_provider_gcp/private/private_provider.py
@@ -129,7 +129,7 @@ class PrivateProvider:
         with open(
                 priv_key, mode='w', opener=open_safe, encoding='UTF-8'
         ) as priv_key_file:
-            priv_key_file.write(keys['private'])
+            priv_key_file.write("%s\n" % keys['private'])
         return keys
 
     def __add_ssh_key(self, blade_type, blade_config):


### PR DESCRIPTION
## Summary and Scope

Fix problems with the 'recurse' option to copy-to and copy-from. Also work around issue with no newline on the end of the private key file when caching.