### PR TITLE
Harmonize args for ssh_connect_blade() and ssh_connect_blades()

### DIFF
--- a/vtds_provider_gcp/api_objects.py
+++ b/vtds_provider_gcp/api_objects.py
@@ -131,7 +131,7 @@ class VirtualBlades(metaclass=ABCMeta):
 
     @contextmanager
     @abstractmethod
-    def ssh_connect_blades(self, remote_port=22, blade_types=None):
+    def ssh_connect_blades(self, blade_types=None, remote_port=22):
         """Establish external connections to the specified remote port
         on all the Virtual Blade instances on all the Virtual Blade
         types listed by name in 'blade_types'. If 'blade_types' is not

--- a/vtds_provider_gcp/private/api_objects.py
+++ b/vtds_provider_gcp/private/api_objects.py
@@ -206,7 +206,7 @@ class PrivateVirtualBlades(VirtualBlades):
             connection._disconnect()  # pylint: disable=protected-access
 
     @contextmanager
-    def ssh_connect_blades(self, remote_port=22, blade_types=None):
+    def ssh_connect_blades(self, blade_types=None, remote_port=22):
         """Establish external connections to the SSH server on all the
         Virtual Blade instances on all the Virtual Blade types listed
         by name in 'blade_types'. If 'blade_types' is not provided or

--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/compute_instance/deploy/terragrunt.hcl
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/compute_instance/deploy/terragrunt.hcl
@@ -70,7 +70,9 @@ inputs = {
   network              = ""
   subnetwork           = format("{{ interconnect_name }}-%s", local.vtds_vars.provider.project.region)
   subnetwork_project   = dependency.service_project.outputs.project_id
+  {% if access_config %}
   access_config        = local.vtds_vars.{{ config_path }}.access_config
+  {% endif %}
   add_hostname_suffix  = local.vtds_vars.{{ config_path }}.add_hostname_suffix
   hostname_suffix_separator = local.vtds_vars.{{ config_path }}.hostname_suffix_separator
   hostname             = local.vtds_vars.{{ config_path }}.hostname

--- a/vtds_provider_gcp/private/virtual_blade.py
+++ b/vtds_provider_gcp/private/virtual_blade.py
@@ -68,6 +68,7 @@ class VirtualBlade:
         try:
             interconnect = blade_config['blade_interconnect']
             boot_disk = blade_config.get('vm', {})['boot_disk']
+            access_config = blade_config.get('access_config', [])
         except KeyError as err:
             raise ContextualError(
                 "missing config in the Virtual Blade class '%s': %s" % (
@@ -79,7 +80,8 @@ class VirtualBlade:
                 'blade_class': key,
                 'interconnect_name': interconnect['subnetwork'],
                 'config_path': "provider.virtual_blades.%s" % key,
-                'source_image_private': boot_disk['source_image_private']
+                'source_image_private': boot_disk['source_image_private'],
+                'access_config': access_config,
             }
         except KeyError as err:
             raise ContextualError(


### PR DESCRIPTION
## Summary and Scope

The arguments for ssh_connect_blade() and ssh_connect_blades() in the VirtualBlades API object were in a different order which would make the two functions harder to use harmoniously in a caller. This re-ordering now, before there are a lot of callers, avoids that. It is mostly cosmetic, but it is a harmless change now that would be a regression later.
