### PR TITLE
Add application_metadata and methods for it to API config objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 dist
 *.egg-info
+build

--- a/vtds_provider_gcp/private/api_objects.py
+++ b/vtds_provider_gcp/private/api_objects.py
@@ -76,6 +76,9 @@ class VirtualBlades(VirtualBladesBase):
             if not virtual_blades[name].get('pure_base_class', False)
         ]
 
+    def application_metadata(self, blade_class):
+        return self.common.blade_application_metadata(blade_class)
+
     def blade_count(self, blade_class):
         return self.common.blade_count(blade_class)
 
@@ -173,17 +176,26 @@ class BladeInterconnects(BladeInterconnectsBase):
                 "the following blade interconnects: %s" % str(missing_names)
             ) from err
 
-    def interconnect_names(self):
-        return self.__interconnects_by_name().keys()
-
-    def ipv4_cidr(self, interconnect_name):
+    def __named_interconnect(self, interconnect_name):
+        """Look up a pspecifically named interconnect and return it.
+        """
         blade_interconnects = self.__interconnects_by_name()
         if interconnect_name not in blade_interconnects:
             raise ContextualError(
                 "requesting ipv4_cidr of unknown blade interconnect '%s'" %
                 interconnect_name
             )
-        interconnect = blade_interconnects.get(interconnect_name, {})
+        return blade_interconnects.get(interconnect_name, {})
+
+    def application_metadata(self, interconnect_name):
+        interconnect = self.__named_interconnect(interconnect_name)
+        return interconnect.get('application_metadata', {})
+
+    def interconnect_names(self):
+        return self.__interconnects_by_name().keys()
+
+    def ipv4_cidr(self, interconnect_name):
+        interconnect = self.__named_interconnect(interconnect_name)
         if 'ipv4_cidr' not in interconnect:
             raise ContextualError(
                 "provider layer configuration error: no 'ipv4_cidr' found in "
@@ -795,3 +807,6 @@ class Secrets(SecretsBase):
 
     def read(self, name):
         return self.secret_manager.read(name)
+
+    def application_metadata(self, name):
+        return self.secret_manager.application_metadata(name)

--- a/vtds_provider_gcp/private/common.py
+++ b/vtds_provider_gcp/private/common.py
@@ -184,6 +184,14 @@ class Common:
             )
         return zone
 
+    def blade_application_metadata(self, blade_class):
+        """Get the 'application_metadata' section of a named blade
+        class.
+
+        """
+        blade = self.__get_blade(blade_class)
+        return blade.get('application_metadata', {})
+
     def blade_hostname(self, blade_class, instance):
         """Get the hostname of a given instance of the specified class
         of Virtual Blade.

--- a/vtds_provider_gcp/private/config/config.yaml
+++ b/vtds_provider_gcp/private/config/config.yaml
@@ -145,9 +145,9 @@ provider:
     # Interconnects.
     #
     # All classes of Blade Interconnects specified here will be
-    # consider for inclusion in the generation of Terragrunt /
-    # Terraform controls and the associatedcreation of GCP objects
-    # witin your project. To suppress generation of Terraform /
+    # considered for inclusion in the generation of Terragrunt /
+    # Terraform controls and the associated creation of GCP objects
+    # within your project. To suppress generation of Terraform /
     # Terragrunt for a base class that is being used purely as a base
     # class, set the 'pure_base_class' parameter to true. This will
     # allow other classes to be derived from the base without making
@@ -284,6 +284,19 @@ provider:
           # next_hop_vpn_tunnel: ""
           # next_hop_ilb: ""
           priority: "1000"
+      # Applications sometimes need concrete configuration information
+      # that is most appropriately stored with the objects implemented
+      # within the layers instead of trying to map information onto
+      # those objects abstractly at the application layer. The
+      # application_metadata section of the configuration is only
+      # understood by a given application layer and provides a place to
+      # put such information. The intent here is that a specific
+      # configuration set used for a given application may place
+      # metadata with API objects for use by the application itself. Use
+      # of application_metadata should be done sparingly and with
+      # caution because it has the power to entangle a given vTDS stack
+      # and make it non-portable.
+      application_metadata: {}
   virtual_blades:
     # Virtual Blades are implemented here as GCP instances, typically
     # with nested virtualization enabled so that the actual node(s)
@@ -401,6 +414,24 @@ provider:
       ipv6_access_config: []
       gpu: null
       resource_policies: []
+      # Applications sometimes need concrete configuration information
+      # that is most appropriately stored with the objects implemented
+      # within the layers instead of trying to map information onto
+      # those objects abstractly at the application layer. The
+      # application_metadata section of the configuration is only
+      # understood by a given application layer and provides a place to
+      # put such information. The intent here is that a specific
+      # configuration set used for a given application may place
+      # metadata with API objects for use by the application itself. Use
+      # of application_metadata should be done sparingly and with
+      # caution because it has the power to entangle a given vTDS stack
+      # and make it non-portable.
+      #
+      # Both the virtual blade class and the virtual blades carried by
+      # the blade class will contain the metadata defined here. There is
+      # no mechanism for making discrete metadata for individual virtual
+      # blades.
+      application_metadata: {}
   secrets:
     # All of the secrets to be used in your vTDS system are declared
     # here, though their values and use may come from other
@@ -425,3 +456,16 @@ provider:
       # less than 16KiB.
       annotations:
         layer: provider
+      # Applications sometimes need concrete configuration information
+      # that is most appropriately stored with the objects implemented
+      # within the layers instead of trying to map information onto
+      # those objects abstractly at the application layer. The
+      # application_metadata section of the configuration is only
+      # understood by a given application layer and provides a place to
+      # put such information. The intent here is that a specific
+      # configuration set used for a given application may place
+      # metadata with API objects for use by the application itself. Use
+      # of application_metadata should be done sparingly and with
+      # caution because it has the power to entangle a given vTDS stack
+      # and make it non-portable.
+      application_metadata: {}

--- a/vtds_provider_gcp/private/secret_manager.py
+++ b/vtds_provider_gcp/private/secret_manager.py
@@ -279,3 +279,11 @@ class SecretManager:
                 "attempt to read value from an unknown secret '%s'" % name
             )
         return self.__read_secret(secret)
+
+    def application_metadata(self, name):
+        """Get the application metadata for a named secret from its
+        config.
+
+        """
+        secret = self.secrets.get(name, None)
+        return secret.get('application_metadata', {})


### PR DESCRIPTION
## Summary and Scope

Add application_metadata and API methods for retrieving it to the Blade Interconnect and Virtual Blade Class configuration API objects. This will support attaching application specific configuration to these configuration items to support Application specific use cases that would be more complex and fragile without the metadata.
