### PR TITLE
Move the configuration massage (inheritance mostly) to consolidate

### DIFF
--- a/vtds_provider_gcp/private/terragrunt.py
+++ b/vtds_provider_gcp/private/terragrunt.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -170,9 +170,7 @@ class TGEnv(VersionManager):
         """Constructor
 
         """
-        # Pick a dummy version that is known to exist (in this case 0.72.5)
-        # because 'latest' doesn't work.
-        VersionManager.__init__(self, common, "tgenv", "terragrunt", "0.72.5")
+        VersionManager.__init__(self, common, "tgenv", "terragrunt", "latest")
 
 
 class Terragrunt:


### PR DESCRIPTION
## Summary and Scope

Switch the GCP provider layer implementation over to using consolidate() to prepare the configuration for use and using prepare() to prepare the supporting files for deployment / management of the vTDS. This supports the development of VSHA-648 which requires the ability to interact with the provider layer during the consolidate() phase.

## Issues and Related PRs

* Supports [VSHA-648](https://jira-pro.it.hpe.com:8443/browse/VSHA-648)

## Testing

Tested on vTDS using the openCHAMI vTDS configuration.