### PR TITLE
Turn off public access / disable versioning on remote state buckets

### DIFF
--- a/vtds_provider_gcp/private/terragrunt/framework/terragrunt.hcl
+++ b/vtds_provider_gcp/private/terragrunt/framework/terragrunt.hcl
@@ -52,7 +52,8 @@ remote_state {
     location               = local.vtds_vars.provider.project.location
     project                = local.vtds_vars.provider.organization.seed_project
     skip_bucket_creation   = false
-    skip_bucket_versioning = false
+    skip_bucket_versioning = true
+    enable_bucket_policy_only = true
   }
   generate = {
     path      = "remotestate.tf"


### PR DESCRIPTION
## Summary and Scope

Turn off public access to the Terraform remote state buckets created in the seed project when new projects are deployed. Also turn off versioning of the objects under those buckets, since that only serves to waste space and there is no meaningful use case for reverting a remote state item to an earlier version or interrogating an earlier version.

Tested by deploying a vTDS system with the new settings and no existing remote state bucket. Verified that public access is denied and versioning is turned off on the newly created remote state bucket.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [VSHA-683](https://jira-pro.it.hpe.com:8443/browse/VSHA-683)