### PR TITLE
Vsha 709

### DIFF
--- a/vtds_provider_gcp/private/config/config.yaml
+++ b/vtds_provider_gcp/private/config/config.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -344,6 +344,72 @@ provider:
     base-blade:
       parent_class: null
       pure_base_class: true
+      # Each blade is a GCP Compute Instance and has an Instance Service
+      # Account associated with it. In the case where that service
+      # account needs additional IAM roles for a given use case, they
+      # can be configured in the 'service_account_iam' section
+      # below. These roles are associatd with resource targets defined
+      # in the templated Terragrunt code for Virtual Blade Service
+      # Account IAM.
+      #
+      # Each entry is a list of GCP IAM Role strings identifying roles
+      # to be granted on the specified resource target to the GCP
+      # Compute Instance Service Account for each GCP Instance
+      # implementing a Virtual Blade of this blade class.
+      service_account_iam:
+        # Roles associated with the billing resource to which the GCP
+        # Project hosting the vTDS cluster belongs. For example:
+        #
+        #    "roles/billing.user"
+        #
+        # is required if the service account is meant to be able to
+        # allocate billable resources to itself, which is necessary if
+        # the service account needs to be able to create its own vTDS
+        # Clusters.
+        billing: []
+        # Roles associated with the GCP folder in which vTDS projects
+        # are grouped. For example, the following permit viewing and
+        # creating projects within the folder:
+        #
+        #    "roles/resourcemanager.folderViewer"
+        #    "roles/resourcemanager.projectCreator"
+        #
+        # They are needed if the service account needs to be able to
+        # create its own vTDS clusters.
+        clusters_folder: []
+        # Roles associated with the GCP project hosting the vTDS cluster
+        # itself.
+        cluster_project: []
+        # Roles associated with the image source for the boot image used
+        # to create Virtual Blades. These are assigned only to the
+        # Instance Service account for the blade and are in addition to
+        # any roles that are automatically assigned to permit access to
+        # private image sources.
+        image_source: []
+        # Roles associated with the organization to which the vTDS
+        # cluster belongs. For example, the following is needed for
+        # service accounts that need to be able to obtain information
+        # about the organization:
+        #
+        #    "roles/resourcemanager.organizationViewer"
+        #
+        # It is needed if the service account needs to be able to
+        # create its own vTDS clusters.
+        organization: []
+        # Roles associated with the vTDS Seed Project used by the vTDS
+        # Cluster. For example, the following are needed by service
+        # accounts that want to be able to store and retrive secrets in
+        # the seed project and if the service account needs to be able
+        # to store and retrieve data within the seed project:
+        #
+        #    "roles/secretmanager.secretAccessor"
+        #    "roles/secretmanager.secretVersionManager"
+        #    "roles/storage.admin"
+        #    "roles/viewer"
+        #
+        # They are needed if the service account needs to be able to
+        # create its own vTDS clusters.
+        seed_project: []
       vm:
         machine_type: n1-standard-4
         min_cpu_platform: ""

--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/README.md
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/README.md
@@ -1,0 +1,24 @@
+The sub-trees in this directory specify IAM deployments for the
+Virtual Blade Service Account that permit configured roles to be
+granted to that Service Account on resources at various points in the
+GCP hierarchy. The Provider Layer configuration contains the role
+assignments categorized by resource to be applied and the templates
+within the sub-trees configure Terragrunt to deploy the appropriate
+IAM settings to grant the role assignments.
+
+At present, the following resource categories are covered by the
+configuration:
+
+- Source Image: roles relating to using private source images sourced
+  from a specific project within the vTDS cluster project.
+- Billing: roles granted by the Billing Account for the vTDS cluster
+- Organization: roles granted by the organization hosting the vTDS cluster
+- Clusters Folder: roles granted by the GCP folder containing vTDS clusters
+- Seed Project: roles granted by the Seed Project used by vTDS to deploy clusters
+- Cluster Project: roles granted by the GCP project hosting the vTDS cluster
+
+As the need for roles granted by other resources arises new
+configuration and new IAM sub-trees will be needed to deploy them. The
+configuration of IAM for a given Virtual Blade's service account is
+found in the `iam` section of the Virtual Blade configuration and
+sub-divided by resource.

--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/billing/deploy/inputs.yaml
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/billing/deploy/inputs.yaml
@@ -1,0 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+source_module:
+  version: "version=8.0.0"
+  url: "tfr:///terraform-google-modules/iam/google//modules/billing_accounts_iam"

--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/billing/deploy/terragrunt.hcl
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/billing/deploy/terragrunt.hcl
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024-2026 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,15 +29,7 @@ include {
 locals {
   vtds_vars   = yamldecode(file(find_in_parent_folders("vtds.yaml")))
   inputs_vars = yamldecode(file("inputs.yaml"))
-}
-
-dependency "service_project" {
-  config_path = find_in_parent_folders("system/project/deploy")
-
-  mock_outputs = {
-    project_number                          = "12345678910"
-    mock_outputs_allowed_terraform_commands = ["validate", "plan"]
-  }
+  billing_account = local.vtds_vars.provider.organization.billing_account
 }
 
 dependency "service_account" {
@@ -54,28 +46,13 @@ terraform {
 }
 
 inputs = {
+  billing_account_ids = [ local.billing_account ]
+  mode                = "additive"
   bindings = {
-    {% if source_image_private -%}
-    # First, set up the role that permits the organization and
-    # instance service accounts to use the image from the source project.
-    "roles/compute.imageUser" = [
-      format("serviceAccount:%s", dependency.service_account.outputs.email),
-      format("serviceAccount:%s@cloudservices.gserviceaccount.com", dependency.service_project.outputs.project_number),
-    ]
-    # Next any additional role bindings for the instance service account only
-    # that might be configured for the private image. It is unlikely that
-    # any of these will be provided, but create them if they are.
-    {%- for role in service_account_iam.seed_project | default([]) %}
+    {%- for role in service_account_iam.billing | default([]) %}
     "{{ role }}" = [
       format("serviceAccount:%s", dependency.service_account.outputs.email),
     ]
     {%- endfor %}
-    {% endif %}
   }
-  mode     = "additive"
-  projects = [
-{% if source_image_private -%}
-      local.vtds_vars.{{ config_path }}.vm.boot_disk.source_image_project
-{% endif %}
-  ]
 }

--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/cluster_project/deploy/inputs.yaml
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/cluster_project/deploy/inputs.yaml
@@ -1,0 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+source_module:
+  version: "version=8.0.0"
+  url: "tfr:///terraform-google-modules/iam/google//modules/projects_iam"

--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/cluster_project/deploy/terragrunt.hcl
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/cluster_project/deploy/terragrunt.hcl
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024-2026 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,17 +27,9 @@ include {
 }
 
 locals {
-  vtds_vars   = yamldecode(file(find_in_parent_folders("vtds.yaml")))
-  inputs_vars = yamldecode(file("inputs.yaml"))
-}
-
-dependency "service_project" {
-  config_path = find_in_parent_folders("system/project/deploy")
-
-  mock_outputs = {
-    project_number                          = "12345678910"
-    mock_outputs_allowed_terraform_commands = ["validate", "plan"]
-  }
+  vtds_vars    = yamldecode(file(find_in_parent_folders("vtds.yaml")))
+  inputs_vars  = yamldecode(file("inputs.yaml"))
+  seed_project = local.vtds_vars.provider.organization.seed_project
 }
 
 dependency "service_account" {
@@ -49,33 +41,30 @@ dependency "service_account" {
   }
 }
 
+dependency "service_project" {
+  config_path = find_in_parent_folders("system/project/deploy")
+
+  mock_outputs = {
+    # The seed project needs to be used here because a 'real' project needs
+    # exist by the name offered by the mock so that it can be queried for
+    # various things by terragrunt during 'plan'.
+    project_id                              = local.seed_project
+    mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  }
+}
+
 terraform {
   source = format("%s?%s", local.inputs_vars.source_module.url, local.inputs_vars.source_module.version)
 }
 
 inputs = {
+  folders  = [ dependency.service_project.outputs.project_id ]
+  mode     = "additive"
   bindings = {
-    {% if source_image_private -%}
-    # First, set up the role that permits the organization and
-    # instance service accounts to use the image from the source project.
-    "roles/compute.imageUser" = [
-      format("serviceAccount:%s", dependency.service_account.outputs.email),
-      format("serviceAccount:%s@cloudservices.gserviceaccount.com", dependency.service_project.outputs.project_number),
-    ]
-    # Next any additional role bindings for the instance service account only
-    # that might be configured for the private image. It is unlikely that
-    # any of these will be provided, but create them if they are.
-    {%- for role in service_account_iam.seed_project | default([]) %}
+    {%- for role in service_account_iam.cluster_project | default([]) %}
     "{{ role }}" = [
       format("serviceAccount:%s", dependency.service_account.outputs.email),
     ]
     {%- endfor %}
-    {% endif %}
   }
-  mode     = "additive"
-  projects = [
-{% if source_image_private -%}
-      local.vtds_vars.{{ config_path }}.vm.boot_disk.source_image_project
-{% endif %}
-  ]
 }

--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/clusters_folder/deploy/inputs.yaml
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/clusters_folder/deploy/inputs.yaml
@@ -1,0 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+source_module:
+  version: "version=8.0.0"
+  url: "tfr:///terraform-google-modules/iam/google//modules/folders_iam"

--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/clusters_folder/deploy/terragrunt.hcl
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/clusters_folder/deploy/terragrunt.hcl
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024-2026 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,15 +31,6 @@ locals {
   inputs_vars = yamldecode(file("inputs.yaml"))
 }
 
-dependency "service_project" {
-  config_path = find_in_parent_folders("system/project/deploy")
-
-  mock_outputs = {
-    project_number                          = "12345678910"
-    mock_outputs_allowed_terraform_commands = ["validate", "plan"]
-  }
-}
-
 dependency "service_account" {
   config_path = find_in_parent_folders("service-account/deploy")
 
@@ -54,28 +45,13 @@ terraform {
 }
 
 inputs = {
+  folders  = [ local.vtds_vars.provider.project.folder_id ]
+  mode     = "additive"
   bindings = {
-    {% if source_image_private -%}
-    # First, set up the role that permits the organization and
-    # instance service accounts to use the image from the source project.
-    "roles/compute.imageUser" = [
-      format("serviceAccount:%s", dependency.service_account.outputs.email),
-      format("serviceAccount:%s@cloudservices.gserviceaccount.com", dependency.service_project.outputs.project_number),
-    ]
-    # Next any additional role bindings for the instance service account only
-    # that might be configured for the private image. It is unlikely that
-    # any of these will be provided, but create them if they are.
-    {%- for role in service_account_iam.seed_project | default([]) %}
+    {%- for role in service_account_iam.clusters_folder | default([]) %}
     "{{ role }}" = [
       format("serviceAccount:%s", dependency.service_account.outputs.email),
     ]
     {%- endfor %}
-    {% endif %}
   }
-  mode     = "additive"
-  projects = [
-{% if source_image_private -%}
-      local.vtds_vars.{{ config_path }}.vm.boot_disk.source_image_project
-{% endif %}
-  ]
 }

--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/organization/deploy/inputs.yaml
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/organization/deploy/inputs.yaml
@@ -1,0 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+source_module:
+  version: "version=8.0.0"
+  url: "tfr:///terraform-google-modules/iam/google//modules/organizations_iam"

--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/organization/deploy/terragrunt.hcl
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/organization/deploy/terragrunt.hcl
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024-2026 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,15 +29,7 @@ include {
 locals {
   vtds_vars   = yamldecode(file(find_in_parent_folders("vtds.yaml")))
   inputs_vars = yamldecode(file("inputs.yaml"))
-}
-
-dependency "service_project" {
-  config_path = find_in_parent_folders("system/project/deploy")
-
-  mock_outputs = {
-    project_number                          = "12345678910"
-    mock_outputs_allowed_terraform_commands = ["validate", "plan"]
-  }
+  org_id      = split("/", local.vtds_vars.provider.organization.org_id)[1]
 }
 
 dependency "service_account" {
@@ -54,28 +46,13 @@ terraform {
 }
 
 inputs = {
+  organizations  = [ local.org_id ]
+  mode     = "additive"
   bindings = {
-    {% if source_image_private -%}
-    # First, set up the role that permits the organization and
-    # instance service accounts to use the image from the source project.
-    "roles/compute.imageUser" = [
-      format("serviceAccount:%s", dependency.service_account.outputs.email),
-      format("serviceAccount:%s@cloudservices.gserviceaccount.com", dependency.service_project.outputs.project_number),
-    ]
-    # Next any additional role bindings for the instance service account only
-    # that might be configured for the private image. It is unlikely that
-    # any of these will be provided, but create them if they are.
-    {%- for role in service_account_iam.seed_project | default([]) %}
+    {%- for role in service_account_iam.organization | default([]) %}
     "{{ role }}" = [
       format("serviceAccount:%s", dependency.service_account.outputs.email),
     ]
     {%- endfor %}
-    {% endif %}
   }
-  mode     = "additive"
-  projects = [
-{% if source_image_private -%}
-      local.vtds_vars.{{ config_path }}.vm.boot_disk.source_image_project
-{% endif %}
-  ]
 }

--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/seed_project/deploy/inputs.yaml
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/seed_project/deploy/inputs.yaml
@@ -1,0 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+source_module:
+  version: "version=8.0.0"
+  url: "tfr:///terraform-google-modules/iam/google//modules/projects_iam"

--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/seed_project/deploy/terragrunt.hcl
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/seed_project/deploy/terragrunt.hcl
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024-2026 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,15 +31,6 @@ locals {
   inputs_vars = yamldecode(file("inputs.yaml"))
 }
 
-dependency "service_project" {
-  config_path = find_in_parent_folders("system/project/deploy")
-
-  mock_outputs = {
-    project_number                          = "12345678910"
-    mock_outputs_allowed_terraform_commands = ["validate", "plan"]
-  }
-}
-
 dependency "service_account" {
   config_path = find_in_parent_folders("service-account/deploy")
 
@@ -54,28 +45,13 @@ terraform {
 }
 
 inputs = {
+  projects  = [ local.vtds_vars.provider.organization.seed_project ]
+  mode     = "additive"
   bindings = {
-    {% if source_image_private -%}
-    # First, set up the role that permits the organization and
-    # instance service accounts to use the image from the source project.
-    "roles/compute.imageUser" = [
-      format("serviceAccount:%s", dependency.service_account.outputs.email),
-      format("serviceAccount:%s@cloudservices.gserviceaccount.com", dependency.service_project.outputs.project_number),
-    ]
-    # Next any additional role bindings for the instance service account only
-    # that might be configured for the private image. It is unlikely that
-    # any of these will be provided, but create them if they are.
     {%- for role in service_account_iam.seed_project | default([]) %}
     "{{ role }}" = [
       format("serviceAccount:%s", dependency.service_account.outputs.email),
     ]
     {%- endfor %}
-    {% endif %}
   }
-  mode     = "additive"
-  projects = [
-{% if source_image_private -%}
-      local.vtds_vars.{{ config_path }}.vm.boot_disk.source_image_project
-{% endif %}
-  ]
 }

--- a/vtds_provider_gcp/private/virtual_blade.py
+++ b/vtds_provider_gcp/private/virtual_blade.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -69,6 +69,7 @@ class VirtualBlade:
             interconnect = blade_config['blade_interconnect']
             boot_disk = blade_config.get('vm', {})['boot_disk']
             access_config = blade_config.get('access_config', [])
+            service_account_iam = blade_config.get('service_account_iam', {})
         except KeyError as err:
             raise ContextualError(
                 "missing config in the Virtual Blade class '%s': %s" % (
@@ -82,6 +83,7 @@ class VirtualBlade:
                 'config_path': "provider.virtual_blades.%s" % key,
                 'source_image_private': boot_disk['source_image_private'],
                 'access_config': access_config,
+                'service_account_iam': service_account_iam,
             }
         except KeyError as err:
             raise ContextualError(


### PR DESCRIPTION
## Summary and Scope

Add base configuration and a method to allow users to configure the GCP Instance Service Accounts for Virtual Blades to have IAM Roles on a limited set of resources. This primarily supports the creation of bastion server vTDS projects that are able to deploy vTDS clusters of their own, but it should be extensible to other uses as well.

This change is fully compatible with existing vTDS configurations and existing vTDS stacks.

## Issues and Related PRs

* Resolves [VSHA-709](https://jira-pro.it.hpe.com:8443/browse/VSHA-709)

## Testing

Tested by using this code to deploy a vTDS System on which I was able to create a Docker container set up with vTDS, and, using the Blade Service account from within the Docker container, deploy and subsequently remove an OpenCHAMI vTDS cluster.