### PR TITLE
fix terragrunt fror cluster project IAM

### DIFF
--- a/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/cluster_project/deploy/terragrunt.hcl
+++ b/vtds_provider_gcp/private/terragrunt/templates/system/platform/virtual-blade/service-account/iam/cluster_project/deploy/terragrunt.hcl
@@ -58,7 +58,7 @@ terraform {
 }
 
 inputs = {
-  folders  = [ dependency.service_project.outputs.project_id ]
+  projects  = [ dependency.service_project.outputs.project_id ]
   mode     = "additive"
   bindings = {
     {%- for role in service_account_iam.cluster_project | default([]) %}


### PR DESCRIPTION
## Summary and Scope

The Terragrunt template for the IAM on the Cluster Project was incorrectly trying to assign permissions on a folder instead of a project. This PR fixes that, allowing permissions on the Cluster Project to be configured correctly.

## Issues and Related PRs

* Partly Resolves [VSHA-713](https://jira-pro.it.hpe.com:8443/browse/VSHA-713)

## Testing

### Test description:

Tested deployment of an OpenCHAMI test runner platform using permissions for the blade service account on the Cluster Project. Verified that the permissions were applied and could be used.

## Risks and Mitigations

None
